### PR TITLE
Restructure SOAP note around Issue Bbjects

### DIFF
--- a/components/Issue.tsx
+++ b/components/Issue.tsx
@@ -90,7 +90,10 @@ export default function Issue({
           className={`flex flex-wrap text-md text-orange-500 py-1 ${soapData.plan.trim() === '' || soapData.plan.trim() === '-' ? '' : 'opacity-0'}`}
         >
           <ExclamationTriangleIcon className="h-6" />
-          <span>Warning: issue does not have any suggested follow-ups.</span>
+          <span>
+            Issue does not have any follow-up plans written or actionable
+            check-ins encoded
+          </span>
         </div>
       </div>
 

--- a/components/Issue.tsx
+++ b/components/Issue.tsx
@@ -1,0 +1,207 @@
+import { Switch } from '@headlessui/react';
+import { useState } from 'react';
+import TextBox from './TextBox';
+
+export default function Issue({
+  title,
+  summary,
+  diagSections,
+  summarySections,
+  autocompleteTriggersOptions,
+  soapData, // TODO: have pieces passsed individually
+  setSoapData, // TODO: have a save function that takes which issue is being edited and which section was updated, and send that back to the main view
+  detectedIssues,
+  followUpPlans,
+  onChange
+}): JSX.Element {
+  const [isDiagMode, setDiagMode] = useState(true);
+  const [shouldHideContent, setShouldHideContent] = useState(false);
+  const [issueTitle, setIssueTitle] = useState(title); // TODO: the state management for changes should be done in the parent component
+
+  return (
+    <div className="border p-2 mb-5">
+      {/* Issue title */}
+      <div className="mb-3 w-full">
+        <label className="w-full m:w-200 font-bold text-xl mr-3 h-8">
+          {/* Issue:{' '} */}
+          <input
+            type="text"
+            value={issueTitle}
+            onChange={(e) => setIssueTitle(e.target.value)}
+            className="w-full text-lg font-normal border px-1"
+          />
+        </label>
+      </div>
+
+      <div>
+        {/* Show or hide note details */}
+        <button
+          className="bg-blue-500 hover:bg-blue-700 text-white text-sm font-bold px-4 h-8 rounded-full mr-3"
+          onClick={() => setShouldHideContent(!shouldHideContent)}
+        >
+          {shouldHideContent ? 'Show Issue Notes' : 'Hide Issue Notes'}
+        </button>
+
+        {/* Switch between diagnosis mode and summary mode */}
+        {!shouldHideContent && (
+          <button
+            className="bg-blue-500 hover:bg-blue-700 text-white text-sm font-bold py-1 px-4 h-8 rounded-full"
+            onClick={() => setDiagMode(!isDiagMode)}
+          >
+            {isDiagMode ? 'Switch to Summary Mode' : 'Switch to Diagnosis Mode'}
+          </button>
+        )}
+      </div>
+
+      {/* Diagnosis mode */}
+      {isDiagMode && !shouldHideContent && (
+        <div>
+          {diagSections.map((section) => (
+            <div className={`w-full`} key={section.name}>
+              <h1 className="font-bold text-xl">{section.title}</h1>
+              {section.name === 'plan' && (
+                <h2 className="text-sm color-grey">
+                  Add plans for Orchestration Engine to follow-up on by typing,
+                  &quot;[script]&quot;. These will be sent to the students&apos;
+                  project channel.
+                </h2>
+              )}
+
+              {/* TODO: abstract out the update code */}
+              {/* TODO: this won't update until the state updating logic is fixed */}
+              <TextBox
+                value={soapData[section.name]}
+                triggers={Object.keys(
+                  autocompleteTriggersOptions[section.name]
+                )}
+                options={autocompleteTriggersOptions[section.name]}
+                onFocus={(e) => {
+                  // add a "- " if the text box is empty
+                  if (e.target.value === '') {
+                    setSoapData((prevSoapData) => {
+                      let newSoapData = { ...prevSoapData };
+                      newSoapData[section.name] = '- ';
+                      return newSoapData;
+                    });
+                  }
+                }}
+                onBlur={(e) => {
+                  // remove the dash if the text box is empty
+                  if (e.target.value.trim() === '-') {
+                    setSoapData((prevSoapData) => {
+                      let newSoapData = { ...prevSoapData };
+                      newSoapData[section.name] = '';
+                      return newSoapData;
+                    });
+                  }
+                }}
+                onKeyUp={(e) => {
+                  // add a new line to the text box with a dash when the user presses enter
+                  if (e.key === 'Enter') {
+                    // check if it's not a script line
+                    let lines = e.target.value.split('\n');
+                    if (
+                      lines.length >= 1 &&
+                      lines[lines.length - 1].includes('[script]')
+                    ) {
+                      return;
+                    }
+
+                    setSoapData((prevSoapData) => {
+                      let newSoapData = { ...prevSoapData };
+                      newSoapData[section.name] = `${e.target.value}- `;
+                      return newSoapData;
+                    });
+                  }
+                }}
+                onChange={(edits) => {
+                  // update the state with the new data
+                  setSoapData((prevSoapData) => {
+                    let newSoapData = { ...prevSoapData };
+                    newSoapData[section.name] = edits;
+                    return newSoapData;
+                  });
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+      {/* Summary mode */}
+      {!isDiagMode && !shouldHideContent && (
+        <div>
+          {summarySections.map((section) => (
+            <div className={`w-full`} key={section.name}>
+              <h1 className="font-bold text-xl">{section.title}</h1>
+              {section.name === 'plan' && (
+                <h2 className="text-sm color-grey">
+                  Add plans for Orchestration Engine to follow-up on by typing,
+                  &quot;[script]&quot;. These will be sent to the students&apos;
+                  project channel.
+                </h2>
+              )}
+
+              <div className="">
+                {/* TODO: abstract out the update code */}
+                <TextBox
+                  value={soapData[section.name]}
+                  triggers={Object.keys(
+                    autocompleteTriggersOptions[section.name]
+                  )}
+                  options={autocompleteTriggersOptions[section.name]}
+                  onFocus={(e) => {
+                    // add a "- " if the text box is empty
+                    if (e.target.value === '') {
+                      setSoapData((prevSoapData) => {
+                        let newSoapData = { ...prevSoapData };
+                        newSoapData[section.name] = '- ';
+                        return newSoapData;
+                      });
+                    }
+                  }}
+                  onBlur={(e) => {
+                    // remove the dash if the text box is empty
+                    if (e.target.value.trim() === '-') {
+                      setSoapData((prevSoapData) => {
+                        let newSoapData = { ...prevSoapData };
+                        newSoapData[section.name] = '';
+                        return newSoapData;
+                      });
+                    }
+                  }}
+                  onKeyUp={(e) => {
+                    // add a new line to the text box with a dash when the user presses enter
+                    if (e.key === 'Enter') {
+                      // check if it's not a script line
+                      let lines = e.target.value.split('\n');
+                      if (
+                        lines.length >= 1 &&
+                        lines[lines.length - 1].includes('[script]')
+                      ) {
+                        return;
+                      }
+
+                      setSoapData((prevSoapData) => {
+                        let newSoapData = { ...prevSoapData };
+                        newSoapData[section.name] = `${e.target.value}- `;
+                        return newSoapData;
+                      });
+                    }
+                  }}
+                  onChange={(edits) => {
+                    // update the state with the new data
+                    setSoapData((prevSoapData) => {
+                      let newSoapData = { ...prevSoapData };
+                      newSoapData[section.name] = edits;
+                      return newSoapData;
+                    });
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Issue.tsx
+++ b/components/Issue.tsx
@@ -11,17 +11,14 @@ import TextBox from './TextBox';
 export default function Issue({
   issueIndex,
   title,
-  summary,
   diagSections,
   summarySections,
   autocompleteTriggersOptions,
-  soapData, // TODO: have pieces passsed individually
-  setSoapData, // TODO: have a save function that takes which issue is being edited and which section was updated, and send that back to the main view
-  detectedIssues,
-  followUpPlans
+  soapData,
+  setSoapData
 }): JSX.Element {
   const [isDiagMode, setDiagMode] = useState(true);
-  const [shouldHideContent, setShouldHideContent] = useState(false);
+  const [shouldHideContent, setShouldHideContent] = useState(true);
 
   return (
     <div className="border p-2 mb-5">

--- a/components/TextBox.tsx
+++ b/components/TextBox.tsx
@@ -1,5 +1,6 @@
 import TextInput from 'react-autocomplete-input';
 import 'react-autocomplete-input/dist/bundle.css';
+import { useState } from 'react';
 
 export default function TextBox({
   value,
@@ -7,21 +8,20 @@ export default function TextBox({
   options,
   onFocus,
   onBlur,
-  onChange,
-  onKeyUp
+  onKeyUp,
+  onChange
 }): JSX.Element {
   return (
-    <div className="">
-      <TextInput
-        trigger={triggers}
-        options={options}
-        placeholder="Type here..."
-        value={value}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onChange={onChange}
-        onKeyUp={onKeyUp}
-      />
-    </div>
+    <TextInput
+      trigger={triggers}
+      options={options}
+      placeholder="Type here..."
+      value={value}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onKeyUp={onKeyUp}
+      onChange={onChange}
+      className="h-20"
+    />
   );
 }

--- a/components/TextBox.tsx
+++ b/components/TextBox.tsx
@@ -1,6 +1,5 @@
 import TextInput from 'react-autocomplete-input';
 import 'react-autocomplete-input/dist/bundle.css';
-import { useState } from 'react';
 
 export default function TextBox({
   value,

--- a/controllers/soapNotes/createSoapNote.ts
+++ b/controllers/soapNotes/createSoapNote.ts
@@ -38,10 +38,7 @@ export const createSOAPNote = async (projectName: string, noteDate: Date) => {
       lastUpdated: noteDate,
       sigName: sigName,
       sigAbbreviation: sigAbbreviation,
-      subjective: '',
-      objective: '',
-      assessment: '',
-      plan: '',
+      issues: [],
       priorContext: [],
       notedAssessments: [],
       followUpContext: []

--- a/controllers/soapNotes/fetchSoapNotes.ts
+++ b/controllers/soapNotes/fetchSoapNotes.ts
@@ -43,13 +43,13 @@ export const fetchSoapNote = async (
     date: { $lt: startDate }
   });
 
-  if (priorSoapNote) {
-    currentSoapNote.priorContext = {
-      notedAssessments: priorSoapNote.notedAssessments,
-      followUpPlans: priorSoapNote.plan
-    };
-    await currentSoapNote.save();
-  }
+  // if (priorSoapNote) {
+  //   currentSoapNote.priorContext = {
+  //     notedAssessments: priorSoapNote.notedAssessments,
+  //     followUpPlans: priorSoapNote.plan
+  //   };
+  //   await currentSoapNote.save();
+  // }
 
   return currentSoapNote;
 };

--- a/models/SOAPModel.ts
+++ b/models/SOAPModel.ts
@@ -1,22 +1,28 @@
 import mongoose from 'mongoose';
 
-export interface SOAP {
+export interface SOAPStruct {
   project: string;
   date: Date;
   lastUpdated: Date;
   sigName: string;
   sigAbbreviation: string;
-  subjective: string;
-  objective: string;
-  assessment: string;
-  plan: string;
+  issues: IssueStruct[];
   priorContext: object;
   notedAssessments: object;
   followUpContext: object;
 }
 
-// TODO: make the SOAP strings required, but allow 0-length strings (https://stackoverflow.com/questions/44320745/in-mongoose-how-do-i-require-a-string-field-to-not-be-null-or-undefined-permitt)
-const SOAPSchema = new mongoose.Schema<SOAP>({
+export interface IssueStruct {
+  title: string;
+  subjective: string;
+  objective: string;
+  assessment: string;
+  plan: string;
+  summary: string;
+  followUpPlans: string[];
+}
+
+const SOAPSchema = new mongoose.Schema<SOAPStruct>({
   project: {
     type: String,
     required: true
@@ -37,21 +43,20 @@ const SOAPSchema = new mongoose.Schema<SOAP>({
     type: String,
     required: true
   },
-  subjective: {
-    type: String,
-    required: true
-  },
-  objective: {
-    type: String,
-    required: true
-  },
-  assessment: {
-    type: String,
-    required: true
-  },
-  plan: {
-    type: String,
-    required: true
+  issues: {
+    type: [
+      {
+        title: String,
+        subjective: String,
+        objective: String,
+        assessment: String,
+        plan: String,
+        summary: String,
+        followUpPlans: [String]
+      }
+    ],
+    required: true,
+    default: []
   },
   priorContext: {
     type: Object,
@@ -67,5 +72,5 @@ const SOAPSchema = new mongoose.Schema<SOAP>({
   }
 });
 
-export default (mongoose.models.SOAPNote as mongoose.Model<SOAP>) ||
+export default (mongoose.models.SOAPNote as mongoose.Model<SOAPStruct>) ||
   mongoose.model('SOAPNote', SOAPSchema);

--- a/models/SOAPModel.ts
+++ b/models/SOAPModel.ts
@@ -19,7 +19,12 @@ export interface IssueStruct {
   assessment: string;
   plan: string;
   summary: string;
-  followUpPlans: string[];
+  followUpPlans: ScriptObj[];
+}
+
+interface ScriptObj {
+  venue: string;
+  strategy: string;
 }
 
 const SOAPSchema = new mongoose.Schema<SOAPStruct>({
@@ -52,7 +57,12 @@ const SOAPSchema = new mongoose.Schema<SOAPStruct>({
         assessment: String,
         plan: String,
         summary: String,
-        followUpPlans: [String]
+        followUpPlans: [
+          {
+            venue: String,
+            strategy: String
+          }
+        ]
       }
     ],
     required: true,

--- a/models/fixtures/soapNotes.ts
+++ b/models/fixtures/soapNotes.ts
@@ -11,14 +11,11 @@ const soapNotesForSigs = [
         project: 'Orchestration Scripting Environments',
         date: new Date('2024-02-12T06:00:00'),
         lastUpdated: new Date('2024-02-12T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
-      },
-    ],
+        followUpContext: {}
+      }
+    ]
   },
   {
     name: 'Human-AI Tools (Difference)',
@@ -28,25 +25,19 @@ const soapNotesForSigs = [
         project: 'Human-AI Tools for Accounting for Differences',
         date: new Date('2024-02-12T06:00:00'),
         lastUpdated: new Date('2024-02-12T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
+        followUpContext: {}
       },
       {
         project: 'Reference Systems',
         date: new Date('2024-02-12T06:00:00'),
         lastUpdated: new Date('2024-02-12T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
-      },
-    ],
+        followUpContext: {}
+      }
+    ]
   },
   {
     name: 'Human-AI Tools (Expression)',
@@ -56,26 +47,20 @@ const soapNotesForSigs = [
         project: 'Human-AI Tools for Concept Expression',
         date: new Date('2024-02-12T06:00:00'),
         lastUpdated: new Date('2024-02-12T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
+        followUpContext: {}
       },
       {
         project:
           'Human-AI Tools for Aligning to Machine Representations and Execution',
         date: new Date('2024-02-12T06:00:00'),
         lastUpdated: new Date('2024-02-12T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
-      },
-    ],
+        followUpContext: {}
+      }
+    ]
   },
   {
     name: 'Breaking Boundaries',
@@ -85,25 +70,19 @@ const soapNotesForSigs = [
         project: 'How Can Computers Support Dialectical Activities?',
         date: new Date('2024-02-12T06:00:00'),
         lastUpdated: new Date('2024-02-12T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
+        followUpContext: {}
       },
       {
         project: 'Prototyping with LLMs',
         date: new Date('2024-02-12T06:00:00'),
         lastUpdated: new Date('2024-02-12T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
-      },
-    ],
+        followUpContext: {}
+      }
+    ]
   },
   {
     name: 'Contextually-Aware Metacognitive Practice',
@@ -113,12 +92,9 @@ const soapNotesForSigs = [
         project: 'Q&A Buddy',
         date: new Date('2024-02-14T06:00:00'),
         lastUpdated: new Date('2024-02-14T06:00:00'),
-        subjective: '',
-        objective: '',
-        assessment: '',
-        plan: '',
+        issues: [],
         priorContext: {},
-        followUpContext: {},
+        followUpContext: {}
       },
       {
         project: 'PATH',
@@ -129,10 +105,10 @@ const soapNotesForSigs = [
         assessment: '',
         plan: '',
         priorContext: {},
-        followUpContext: {},
-      },
-    ],
-  },
+        followUpContext: {}
+      }
+    ]
+  }
 ];
 
 export const createSoapNoteFixtures = async () => {
@@ -153,13 +129,10 @@ export const createSoapNoteFixtures = async () => {
           project: soapNote.project,
           date: soapNote.date,
           lastUpdated: soapNote.lastUpdated,
-          subjective: soapNote.subjective,
-          objective: soapNote.objective,
-          assessment: soapNote.assessment,
-          plan: soapNote.plan,
+          issues: soapNote.issues,
           priorContext: [],
           notedAssessments: [],
-          followUpContext: [],
+          followUpContext: []
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@editorjs/paragraph": "^2.11.3",
     "@editorjs/simple-image": "^1.6.0",
     "@editorjs/table": "^2.3.0",
+    "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
     "@tailwindcss/typography": "^0.5.10",
     "bootstrap": "^5.3.2",

--- a/pages/api/soap/index.ts
+++ b/pages/api/soap/index.ts
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSOAPNote } from '../../../controllers/soapNotes/createSoapNote';
-import { SOAP } from '../../../models/SOAPModel';
+import { SOAPStruct } from '../../../models/SOAPModel';
 
 type Data = {
   msg: string;
   success: boolean;
-  data?: SOAP;
+  data?: SOAPStruct;
   error?: any;
 };
 
@@ -29,7 +29,10 @@ export default async function handler(
       try {
         projectName = req.body.projectName;
         noteDate = new Date(req.body.noteDate);
-        let createdSOAPNote: SOAP = await createSOAPNote(projectName, noteDate);
+        let createdSOAPNote: SOAPStruct = await createSOAPNote(
+          projectName,
+          noteDate
+        );
         res.status(200).json({
           msg: 'Soap note created',
           success: true,

--- a/pages/soap-notes/[id].tsx
+++ b/pages/soap-notes/[id].tsx
@@ -2,10 +2,11 @@ import type { GetServerSideProps, NextPage } from 'next';
 import { useEffect, useState, useRef } from 'react';
 
 import TextBox from '../../components/TextBox';
+import Issue from '../../components/Issue';
 import Link from 'next/link';
 import { fetchSoapNote } from '../../controllers/soapNotes/fetchSoapNotes';
 import { mutate } from 'swr';
-import { SOAP } from '../../models/SOAPModel';
+import { SOAPStruct, IssueStruct } from '../../models/SOAPModel';
 import Head from 'next/head';
 import { longDate, shortDate } from '../../lib/helperFns';
 
@@ -51,27 +52,32 @@ export default function SOAPNote({
       const lastUpdated = new Date();
 
       // check if any lines have a [script] tag
-      let lines = soapData.plan.split('\n');
-      let scripts = lines.filter((line) => line.includes('[script]'));
+      // TODO: need to repeat this on every issue
+      for (let issue of soapData.issues) {
+        let lines = issue.plan.split('\n');
+        let scripts = lines.filter((line) => line.includes('[script]'));
 
-      // create objects for each script
-      let output = [];
-      for (let script of scripts) {
-        // check if the script is fully written before adding it to output
-        let splitFollowUp = script.split('[script]')[1].split(':');
-        if (
-          splitFollowUp.length < 2 ||
-          splitFollowUp[1].trim() === '[follow-up to send]' ||
-          splitFollowUp[1].trim() === ''
-        ) {
-          continue;
-        } else {
-          let [venue, strategy] = splitFollowUp;
-          output.push({
-            venue: venue.trim(),
-            strategy: strategy.trim()
-          });
+        // create objects for each script
+        let output = [];
+        for (let script of scripts) {
+          // check if the script is fully written before adding it to output
+          let splitFollowUp = script.split('[script]')[1].split(':');
+          if (
+            splitFollowUp.length < 2 ||
+            splitFollowUp[1].trim() === '[follow-up to send]' ||
+            splitFollowUp[1].trim() === ''
+          ) {
+            continue;
+          } else {
+            let [venue, strategy] = splitFollowUp;
+            output.push({
+              venue: venue.trim(),
+              strategy: strategy.trim()
+            });
+          }
         }
+
+        issue.followUpPlans = output;
       }
 
       let dataToSave = {
@@ -80,32 +86,29 @@ export default function SOAPNote({
         lastUpdated: lastUpdated,
         sigName: soapNoteInfo.sigName,
         sigAbbreviation: soapNoteInfo.sigAbbreviation,
-        subjective: soapData.subjective,
-        objective: soapData.objective,
-        assessment: soapData.assessment,
-        plan: soapData.plan,
+        issues: soapData.issues,
         priorContext: soapData.priorContext,
         notedAssessments: [],
-        followUpContext: output
+        followUpContext: {}
       };
 
-      try {
-        const res = await fetch(`/api/soap/${soapNoteInfo.id}`, {
-          method: 'PUT',
-          body: JSON.stringify(dataToSave),
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        });
+      // try {
+      //   const res = await fetch(`/api/soap/${soapNoteInfo.id}`, {
+      //     method: 'PUT',
+      //     body: JSON.stringify(dataToSave),
+      //     headers: {
+      //       'Content-Type': 'application/json'
+      //     }
+      //   });
 
-        // TODO: last update date isn't working
-        // TODO: why am i doing this lol?
-        // Update the local data without a revalidation
-        const { data } = await res.json();
-        mutate(`/api/soap/${soapNoteInfo.id}`, data, false);
-      } catch (err) {
-        console.log(err);
-      }
+      //   // TODO: last update date isn't working
+      //   // TODO: why am i doing this lol?
+      //   // Update the local data without a revalidation
+      //   const { data } = await res.json();
+      //   mutate(`/api/soap/${soapNoteInfo.id}`, data, false);
+      // } catch (err) {
+      //   console.log(err);
+      // }
 
       setNoteInfo((prevNoteInfo) => ({
         ...prevNoteInfo,
@@ -119,7 +122,7 @@ export default function SOAPNote({
   }, [soapData, soapNoteInfo]);
 
   // sections of the soap notes
-  const sections = [
+  const diagnosisSections = [
     {
       name: 'subjective',
       title: 'Subjective information from student(s)'
@@ -132,6 +135,17 @@ export default function SOAPNote({
       name: 'assessment',
       title:
         'Assessment of situation (e.g., obstacles to practice; metacogntive blockers)'
+    },
+    {
+      name: 'plan',
+      title: 'Plan for follow-up and check-ins'
+    }
+  ];
+
+  const summarySections = [
+    {
+      name: 'summary',
+      title: 'Summary of issue'
     },
     {
       name: 'plan',
@@ -221,97 +235,39 @@ export default function SOAPNote({
         {/* Create a section for each component of the SOAP notes */}
         {/* resizing textbox: https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/ */}
         <div className="w-full col-span-2">
-          <h1 className="font-bold text-2xl border-b  border-black mb-3">
+          <h1 className="font-bold text-2xl border-b border-black mb-3">
             This week&apos;s notes
           </h1>
-          {sections.map((section) => (
-            <div
-              className={`w-full ${
-                ['assessment', 'plan'].includes(section.name)
-                  ? 'col-span-2'
-                  : 'col-span-1'
-              }`}
-              key={section.name}
-            >
-              <h1 className="font-bold text-xl">{section.title}</h1>
-              {section.name === 'plan' && (
-                <h2 className="text-sm color-grey">
-                  Add plans for Orchestration Engine to follow-up on by typing,
-                  &quot;[script]&quot;. These will be sent to the students&apos;
-                  project channel.
-                </h2>
-              )}
-
-              <div className="">
-                {/* TODO: abstract out the update code */}
-                <TextBox
-                  value={soapData[section.name]}
-                  triggers={Object.keys(
-                    autocompleteTriggersOptions[section.name]
-                  )}
-                  options={autocompleteTriggersOptions[section.name]}
-                  onFocus={(e) => {
-                    // add a "- " if the text box is empty
-                    if (e.target.value === '') {
-                      setSoapData((prevSoapData) => {
-                        let newSoapData = { ...prevSoapData };
-                        newSoapData[section.name] = '- ';
-                        return newSoapData;
-                      });
-                    }
-                  }}
-                  onBlur={(e) => {
-                    // remove the dash if the text box is empty
-                    if (e.target.value.trim() === '-') {
-                      setSoapData((prevSoapData) => {
-                        let newSoapData = { ...prevSoapData };
-                        newSoapData[section.name] = '';
-                        return newSoapData;
-                      });
-                    }
-                  }}
-                  onKeyUp={(e) => {
-                    // add a new line to the text box with a dash when the user presses enter
-                    if (e.key === 'Enter') {
-                      // check if it's not a script line
-                      let lines = e.target.value.split('\n');
-                      if (
-                        lines.length >= 1 &&
-                        lines[lines.length - 1].includes('[script]')
-                      ) {
-                        return;
-                      }
-
-                      setSoapData((prevSoapData) => {
-                        let newSoapData = { ...prevSoapData };
-                        newSoapData[section.name] = `${e.target.value}- `;
-                        return newSoapData;
-                      });
-                    }
-                  }}
-                  onChange={(edits) => {
-                    // update the state with the new data
-                    setSoapData((prevSoapData) => {
-                      let newSoapData = { ...prevSoapData };
-                      newSoapData[section.name] = edits;
-                      return newSoapData;
-                    });
-                  }}
-                />
-              </div>
-            </div>
+          {soapData.issues.map((issue, i) => (
+            <Issue
+              key={`issue-index-${i}`}
+              title={issue.title}
+              summary={issue.summary}
+              diagSections={diagnosisSections}
+              summarySections={summarySections}
+              autocompleteTriggersOptions={autocompleteTriggersOptions}
+              soapData={{
+                subjective: issue.subjective,
+                objective: issue.objective,
+                assessment: issue.assessment,
+                plan: issue.plan,
+                summary: issue.summary,
+                followUpPlans: issue.followUpPlans
+              }}
+              setSoapData={setSoapData} // TODO: this needs to be per issue
+              detectedIssues=""
+              followUpPlans=""
+              onChange={(edits) => {
+                console.log(edits);
+              }}
+            />
           ))}
-
-          {/* Define actionable follow-ups a mentor can input
-        <div>
-          <h2 className="font-bold text-xl">Actionable follow-ups</h2>
-          <select name="cars" id="cars">
-            <option value="volvo">Volvo</option>
-            <option value="saab">Saab</option>
-            <option value="mercedes">Mercedes</option>
-            <option value="audi">Audi</option>
-          </select>
-        </div> */}
+          <button
+            className="bg-blue-500 hover:bg-blue-700 text-white text-sm font-bold px-4 h-8 rounded-full mr-3"
+            onClick={() => {}}
+          >
+            Add Issue
+          </button>
         </div>
       </div>
     </>
@@ -324,6 +280,7 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
   let [sigAbbrev, project, date] = (query.params?.id as string).split('_');
 
   // fetch SOAP note for the given sig and date
+  // TODO: see how I can add type checking to this
   const currentSoapNote = await fetchSoapNote(sigAbbrev, project, date);
 
   // fetch contextual data from OS
@@ -402,23 +359,34 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
   }
 
   // setup tracked scripts
-  let trackedScripts = triggeredScripts.map((script) => {
-    return `- [detected issue] ${script.name} - ${script.strategies}`;
-  });
-  // if (trackedScripts.length === 0) {
-  //   trackedScripts = ['no detected issues'];
-  // }
-
-  // create a text object with scripts added before objective
-  let objectiveTextList = currentSoapNote.objective.split('\n');
-  let filteredObjectiveTextList = objectiveTextList.filter(
-    (line) => !line.includes('[detected issue]')
-  );
-  let objectiveText = trackedScripts
-    .concat(filteredObjectiveTextList)
-    .join('\n')
-    .trim();
-  console.log(objectiveText);
+  // check if title doesn't match any existing issue titles
+  // TODO: should have the context from what triggered the script injected into the issue object
+  // TODO: sort by detected issues first
+  let noteIssues = currentSoapNote.toObject().issues;
+  for (let script of triggeredScripts) {
+    let title = script.name;
+    let titleIndex = noteIssues.findIndex((issue) => issue.title === title);
+    if (titleIndex === -1) {
+      console.log('new issue to add', {
+        title: `[detected issue] ${title} - ${script.strategies}`,
+        subjective: '',
+        objective: '',
+        assessment: '',
+        plan: '',
+        summary: '',
+        followUpPlans: []
+      });
+      noteIssues.push({
+        title: `[detected issue] ${title} - ${script.strategies}`,
+        subjective: '',
+        objective: '',
+        assessment: '',
+        plan: '',
+        summary: '',
+        followUpPlans: []
+      });
+    }
+  }
 
   // setup the page with the data from the database
   // TODO: populate view with the following
@@ -434,18 +402,18 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
         ['Sprint Stories'],
         sprintStories
       ),
-      triggeredScripts: trackedScripts,
+      triggeredScripts: [],
       followUpPlans: 'none'
     },
-    subjective: currentSoapNote.subjective,
-    objective: objectiveText,
-    assessment: currentSoapNote.assessment,
-    plan: currentSoapNote.plan
+    issues: noteIssues
   };
+
+  console.log('note data', data);
 
   // setup triggers and options for each section's text boxes
   // TODO: have controllers that abstract this
   const autocompleteTriggersOptions = {
+    summary: {},
     subjective: {},
     objective: {},
     assessment: {

--- a/pages/soap-notes/[id].tsx
+++ b/pages/soap-notes/[id].tsx
@@ -241,6 +241,7 @@ export default function SOAPNote({
           {soapData.issues.map((issue, i) => (
             <Issue
               key={`issue-index-${i}`}
+              issueIndex={i}
               title={issue.title}
               summary={issue.summary}
               diagSections={diagnosisSections}
@@ -257,14 +258,27 @@ export default function SOAPNote({
               setSoapData={setSoapData} // TODO: this needs to be per issue
               detectedIssues=""
               followUpPlans=""
-              onChange={(edits) => {
-                console.log(edits);
-              }}
             />
           ))}
           <button
             className="bg-blue-500 hover:bg-blue-700 text-white text-sm font-bold px-4 h-8 rounded-full mr-3"
-            onClick={() => {}}
+            onClick={() => {
+              setSoapData((prevSoapData) => ({
+                ...prevSoapData,
+                issues: [
+                  ...prevSoapData.issues,
+                  {
+                    title: '',
+                    subjective: '',
+                    objective: '',
+                    assessment: '',
+                    plan: '',
+                    summary: '',
+                    followUpPlans: []
+                  }
+                ]
+              }));
+            }}
           >
             Add Issue
           </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,6 +145,14 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
+"@headlessui/react@^1.7.18":
+  version "1.7.18"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.18.tgz#30af4634d2215b2ca1aa29d07f33d02bea82d9d7"
+  integrity sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==
+  dependencies:
+    "@tanstack/react-virtual" "^3.0.0-beta.60"
+    client-only "^0.0.1"
+
 "@heroicons/react@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.1.1.tgz#422deb80c4d6caf3371aec6f4bee8361a354dc13"
@@ -456,6 +464,18 @@
     lodash.isplainobject "^4.0.6"
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
+
+"@tanstack/react-virtual@^3.0.0-beta.60":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.1.2.tgz#eb62b73cc82e34860604cd3d682a17db590f3c45"
+  integrity sha512-qibmxtctgOZo2I+3Rw5GR9kXgaa15U5r3/idDY1ItUKW15UK7GhCfyIfE6qYuJ1fxQF6dJDsD8SbpPyuJgpxuA==
+  dependencies:
+    "@tanstack/virtual-core" "3.1.2"
+
+"@tanstack/virtual-core@3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.1.2.tgz#ca76f28f826fbd3310f88c3cd355d9c4aba80abb"
+  integrity sha512-DATZJs8iejkIUqXZe6ruDAnjFo78BKnIIgqQZrc7CmEFqfLEN/TPD91n4hRfo6hpRB6xC00bwKxv7vdjFNEmOg==
 
 "@types/debug@^4.0.0":
   version "4.1.12"


### PR DESCRIPTION
SOAP previously was one diagnostic structure for the entire note, but often multiple issues occur in SIG that have different discussion "threads". To better support this, the revised version of SOAP is now focused around issues -- like those detected by OS, noticed by a mentor, or raised by a student. Each has it's own diagnostic model and follow-ups now so that the discussion for different issues can be traced separately (which will be helpful when thinking about building context from Slack onto them).