### PR TITLE
Fixes for readability + timestamps + single saving useEffect

### DIFF
--- a/components/CurrWeekIssueCard.tsx
+++ b/components/CurrWeekIssueCard.tsx
@@ -182,9 +182,10 @@ export default function CurrWeekIssueCard({
                 id={`title-${issueId}`}
                 html={titleRef.current}
                 onKeyUp={(e) => {
+                  const issueTitle = htmlToText(titleRef.current).trim();
                   if (e.key === 'Enter') {
                     // check if blank first
-                    let input = titleRef.current;
+                    let input = issueTitle;
                     if (input === '') {
                       return;
                     }
@@ -195,7 +196,7 @@ export default function CurrWeekIssueCard({
                   }
 
                   // set state holding issue to empty if enter was pressed, otherwise the current text
-                  setNewIssue(titleRef.current);
+                  setNewIssue(issueTitle);
                 }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
@@ -203,7 +204,7 @@ export default function CurrWeekIssueCard({
                   }
                 }}
                 onChange={(e) => {
-                  titleRef.current = htmlToText(e.target.value);
+                  titleRef.current = e.target.value;
                 }}
                 className={`p-1 mr-2 w-full min-h-16 mb-2 break-words flex-none empty:before:content-['Describe_an_item_of_concern...'] empty:before:italic empty:before:text-slate-500 border text-xs font-normal rounded-lg`}
               />
@@ -223,9 +224,7 @@ export default function CurrWeekIssueCard({
                 html={titleRef.current}
                 onChange={(e) => {
                   titleRef.current = e.target.value.trim();
-                  onTitleEdit(
-                    e.target.value.trim().replace(/<\/?[^>]+(>|$)/g, '')
-                  );
+                  onTitleEdit(htmlToText(e.target.value).trim());
                 }}
                 className={`p-0.5 mr-2 w-full min-h-16 mb-1 break-words flex-none empty:before:content-['Describe_concern_you_observed...'] empty:before:italic empty:before:text-slate-400 border text-xs font-normal rounded-lg`}
               />

--- a/components/CurrWeekIssueCard.tsx
+++ b/components/CurrWeekIssueCard.tsx
@@ -28,7 +28,14 @@ export default function CurrWeekIssueCard({
   // onAddIssue is a function that adds a new issue to the current issues
   const onAddIssue = (newIssueTitle) => {
     let newIssueForWeek = serializeDates(
-      createNewIssueObject(newIssueTitle, project, sig, date, [], true)
+      createNewIssueObject(
+        newIssueTitle,
+        project,
+        sig,
+        new Date(date).toISOString(),
+        [],
+        true
+      )
     );
     setCurrentIssuesData((prevData) => {
       return [...prevData, newIssueForWeek];
@@ -50,7 +57,7 @@ export default function CurrWeekIssueCard({
     setCurrentIssuesData((prevData) => {
       let issuesToUpdate = [...prevData];
       let issueIndex = issuesToUpdate.findIndex((i) => i.id === issueId);
-      issuesToUpdate[issueIndex].lastUpdated = longDate(new Date());
+      issuesToUpdate[issueIndex].lastUpdated = new Date().toISOString();
       issuesToUpdate[issueIndex].wasDeleted = true;
       return issuesToUpdate;
     });
@@ -67,6 +74,7 @@ export default function CurrWeekIssueCard({
       let issuesToUpdate = [...prevData];
       let issueIndex = issuesToUpdate.findIndex((i) => i.id === issueId);
       issuesToUpdate[issueIndex].title = value;
+      issuesToUpdate[issueIndex].lastUpdated = new Date().toISOString();
       return issuesToUpdate;
     });
   };

--- a/components/CurrWeekIssuePane.tsx
+++ b/components/CurrWeekIssuePane.tsx
@@ -295,8 +295,8 @@ export default function CurrWeekIssuePane({
                                 title: noteBlock.value
                                   .trim()
                                   .replace(/<\/?[^>]+(>|$)/g, ''),
-                                date: longDate(new Date()),
-                                lastUpdated: longDate(new Date()),
+                                date: new Date().toISOString(),
+                                lastUpdated: new Date().toISOString(),
                                 context: editsToIssue['context'],
                                 assessment: editsToIssue['assessment'],
                                 plan: editsToIssue['plan'],
@@ -333,8 +333,8 @@ export default function CurrWeekIssuePane({
                                 // if the current instance doesn't exist, intialize it with the additions from the notetaking space
                                 issueInstance = {
                                   id: new mongoose.Types.ObjectId().toString(),
-                                  date: longDate(new Date(new Date())),
-                                  lastUpdated: longDate(new Date()),
+                                  date: new Date().toISOString(),
+                                  lastUpdated: new Date().toISOString(),
                                   context: editsToIssue['context'],
                                   assessment: editsToIssue['summary'],
                                   plan: editsToIssue['plan'],
@@ -387,7 +387,7 @@ export default function CurrWeekIssuePane({
                                 }
 
                                 // update the last updated date
-                                issueInstance.date = longDate(new Date());
+                                issueInstance.date = new Date().toISOString();
                               }
 
                               setCAPData((prevCAPData) => {
@@ -395,7 +395,7 @@ export default function CurrWeekIssuePane({
                                 newcurrentIssuesData[issueIndex] =
                                   issueInstance;
                                 newcurrentIssuesData[issueIndex].lastUpdated =
-                                  longDate(new Date());
+                                  new Date().toISOString();
 
                                 return newCAPData;
                               });
@@ -677,7 +677,7 @@ export default function CurrWeekIssuePane({
                               key={`issue-card-${practiceGap.id}`}
                               project={project}
                               sig={sig}
-                              date={date}
+                              date={new Date(date).toISOString()}
                               practiceGapId={practiceGap.id}
                               practiceGap={practiceGap}
                               practiceGapsData={practiceGapData}
@@ -695,7 +695,7 @@ export default function CurrWeekIssuePane({
                           key="issue-card-add-practice"
                           project={project}
                           sig={sig}
-                          date={date}
+                          date={new Date(date).toISOString()}
                           practiceGapId="add-practice"
                           practiceGap={null}
                           practiceGapsData={practiceGapData}

--- a/components/CurrWeekIssuePane.tsx
+++ b/components/CurrWeekIssuePane.tsx
@@ -32,7 +32,7 @@ export default function CurrWeekIssuePane({
   const capSections = [
     {
       name: 'context',
-      title: "Context: what are you hearing or seeing that's bothering you?"
+      title: 'Context: what are you observing related to this issue?'
     },
     {
       name: 'assessment',

--- a/components/LastWeekIssueCard.tsx
+++ b/components/LastWeekIssueCard.tsx
@@ -40,7 +40,7 @@ export default function LastWeekIssueCard({
           sourcePastIssue.title,
           sourcePastIssue.project,
           sourcePastIssue.sig,
-          date,
+          new Date().toISOString(),
           [sourcePastIssue.id]
         );
 

--- a/components/LastWeekIssuePane.tsx
+++ b/components/LastWeekIssuePane.tsx
@@ -334,7 +334,7 @@ export default function LastWeekIssuePane({
                             key={`issue-card-${practiceGap.id}`}
                             project={noteInfo.project}
                             sig={noteInfo.sigName}
-                            date={noteInfo.sigDate}
+                            date={new Date(noteInfo.sigDate).toISOString()}
                             practiceGapId={practiceGap.id}
                             practiceGap={practiceGap}
                             practiceGapsData={practiceGapData}

--- a/components/NoteBlock.tsx
+++ b/components/NoteBlock.tsx
@@ -215,7 +215,10 @@ export default function NoteBlock({
               blockContent.current = e.target.value;
 
               // save note changes
-              onChange(e.target.value, htmlToText(e.target.value));
+              onChange(
+                blockContent.current,
+                htmlToText(blockContent.current).trim()
+              );
             }}
             onKeyDown={onKeyDown}
             onKeyUp={onKeyUp}

--- a/components/NoteBlockForPlan.tsx
+++ b/components/NoteBlockForPlan.tsx
@@ -104,7 +104,7 @@ export default function NoteBlockForPlan({
         className="border shadow flex flex-col items-left align-middle mb-2 w-full"
         key={`note-block-${noteId}`}
       >
-        <div className="flex flex-row h-12">
+        <div className="flex flex-row h-16">
           {/* drag handle on left side */}
           <div
             className={`flex items-center fill-slate-200 stroke-slate-200 ${opacity}`}

--- a/components/NoteBlockForPlan.tsx
+++ b/components/NoteBlockForPlan.tsx
@@ -137,7 +137,7 @@ export default function NoteBlockForPlan({
               onKeyDown={onKeyDown}
               onChange={(value) => {
                 setBlockContent(value);
-                onChange(value, htmlToText(value));
+                onChange(value, htmlToText(value).trim());
               }}
               className={`h-full px-1 py-1 border-none rounded-none leading-normal flex-initial basis-full text-xs text-wrap break-words placeholder:italic placeholder:text-slate-400`}
             />

--- a/components/PracticeGapCard.tsx
+++ b/components/PracticeGapCard.tsx
@@ -177,9 +177,10 @@ export default function PracticeGapCard({
                     id={`title-${practiceGapId}`}
                     html={titleRef.current}
                     onKeyUp={(e) => {
+                      const practiceTitle = htmlToText(titleRef.current).trim();
                       if (e.key === 'Enter') {
                         // check if blank first
-                        let input = titleRef.current;
+                        let input = practiceTitle;
                         if (input === '') {
                           return;
                         }
@@ -190,7 +191,7 @@ export default function PracticeGapCard({
                       }
 
                       // set state holding issue to empty if enter was pressed, otherwise the current text
-                      setNewPractice(titleRef.current);
+                      setNewPractice(practiceTitle);
                     }}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
@@ -198,7 +199,7 @@ export default function PracticeGapCard({
                       }
                     }}
                     onChange={(e) => {
-                      titleRef.current = htmlToText(e.target.value);
+                      titleRef.current = e.target.value;
                     }}
                     className={`p-1 mr-2 w-full min-h-16 mb-2 break-words flex-none empty:before:content-['Describe_the_recurring_gap_in_self\-regulation_skill...'] empty:before:italic empty:before:text-slate-500 border text-xs font-normal rounded-lg`}
                   />
@@ -219,8 +220,8 @@ export default function PracticeGapCard({
                       id={`title-${practiceGapId}`}
                       html={titleRef.current}
                       onChange={(e) => {
-                        titleRef.current = htmlToText(e.target.value);
-                        onEdit('title', titleRef.current);
+                        titleRef.current = e.target.value;
+                        onEdit('title', htmlToText(titleRef.current).trim());
                       }}
                       className={`p-0.5 break-words w-11/12 empty:before:content-['Title_of_practice_gap...'] empty:before:italic empty:before:text-slate-400 border rounded-md text-xs font-normal`}
                     />
@@ -242,8 +243,11 @@ export default function PracticeGapCard({
                       id={`description-${practiceGapId}`}
                       html={descriptionRef.current}
                       onChange={(e) => {
-                        descriptionRef.current = htmlToText(e.target.value);
-                        onEdit('description', e.target.value);
+                        descriptionRef.current = e.target.value;
+                        onEdit(
+                          'description',
+                          htmlToText(descriptionRef.current).trim()
+                        );
                       }}
                       className={`p-0.5 text-xs mt-2 flex-none w-full empty:before:content-['Describe_practice_gap...'] empty:before:italic empty:before:text-slate-400 border rounded-md`}
                     />

--- a/components/PracticeGapCard.tsx
+++ b/components/PracticeGapCard.tsx
@@ -34,7 +34,7 @@ export default function PracticeGapCard({
       project,
       sig,
       '',
-      date,
+      new Date(date).toISOString(),
       [],
       true
     );
@@ -63,7 +63,7 @@ export default function PracticeGapCard({
         (i) => i.id === practiceGapId
       );
       practiceToUpdate[practiceIndex].practiceInactive = true;
-      practiceToUpdate[practiceIndex].lastUpdated = longDate(new Date());
+      practiceToUpdate[practiceIndex].lastUpdated = new Date().toISOString();
       return practiceToUpdate;
     });
   };
@@ -75,7 +75,7 @@ export default function PracticeGapCard({
         (i) => i.id === practiceGapId
       );
       practiceToUpdate[practiceIndex][field] = edits;
-      practiceToUpdate[practiceIndex].lastUpdated = longDate(new Date());
+      practiceToUpdate[practiceIndex].lastUpdated = new Date().toISOString();
       return practiceToUpdate;
     });
   };
@@ -107,7 +107,8 @@ export default function PracticeGapCard({
           `[practice gap] ${sourcePractice.title}`
         )
       );
-      newCurrentIssuesData[targetIssueIndex].lastUpdated = longDate(new Date());
+      newCurrentIssuesData[targetIssueIndex].lastUpdated =
+        new Date().toISOString();
 
       // add issue to practice gap
       setPracticeGapsData((prevData) => {

--- a/controllers/followUpObjects/createFollowUpStrategies.ts
+++ b/controllers/followUpObjects/createFollowUpStrategies.ts
@@ -15,20 +15,10 @@ export const createPostSigMessage = (
   practiceAgents,
   orgObjs
 ) => {
-  console.log('noteDate', noteDate);
   let currDate = new Date(noteDate);
-  currDate.setHours(currDate.getHours() + 5); // HACK FOR CHICAGO / UTC ISSUES: add 5 hours to avoid timezone issues
   let weekFromCurrDate = new Date(currDate.getTime());
   weekFromCurrDate.setDate(weekFromCurrDate.getDate() + 7);
   let timezone = 'America/Chicago';
-
-  // console.log(currDate.toUTCString(), weekFromCurrDate.toUTCString());
-  // console.log('orignal dates', currDate, weekFromCurrDate);
-  // console.log(
-  //   'new timezone dates',
-  //   convertTZ(currDate, timezone),
-  //   convertTZ(weekFromCurrDate, timezone)
-  // );
 
   let newActiveIssue = {
     scriptId: crypto
@@ -94,11 +84,9 @@ export const createPostSigMessage = (
     });
   }.toString();
 
-  console.log(strategyFunction);
-
   strategyFunction = strategyFunction.replace(
     'currDate',
-    currDate.toUTCString()
+    currDate.toISOString()
   );
   strategyFunction = strategyFunction.replace('timezone', timezone);
   strategyFunction = strategyFunction.replace(

--- a/controllers/issueObjects/createIssueObject.ts
+++ b/controllers/issueObjects/createIssueObject.ts
@@ -9,14 +9,14 @@ export const createNewIssueObject = (
   title: string,
   project: string,
   sig: string,
-  currentDate: Date = new Date(),
+  currentDate: string = new Date().toISOString(),
   priorInstances: string[] = [],
   includeId: boolean = false
 ): IssueObjectStruct => {
   // TODO: create new CAP placeholder fields
   let newIssueObject: IssueObjectStruct = {
     title: title,
-    date: currentDate,
+    date: new Date(currentDate),
     project: project,
     sig: sig,
     lastUpdated: new Date(),

--- a/controllers/practiceGapObjects/createPracticeGapObject.ts
+++ b/controllers/practiceGapObjects/createPracticeGapObject.ts
@@ -6,17 +6,17 @@ export const createNewPracticeGapObject = (
   project: string,
   sig: string,
   description: string,
-  currentDate: Date = new Date(),
+  currentDate: string = new Date().toISOString(),
   priorIssues: Types.ObjectId[] = [],
   includeId: boolean = false
 ): PracticeGapObjectStruct => {
   let newPracticeGapObject: PracticeGapObjectStruct = {
     title: title,
-    date: currentDate,
+    date: new Date(currentDate),
     project: project,
     sig: sig,
     description: description,
-    lastUpdated: currentDate,
+    lastUpdated: new Date(currentDate),
     practiceInactive: false,
     practiceArchived: false,
     prevIssues: priorIssues

--- a/controllers/practiceGapObjects/updatePracticeGapObject.ts
+++ b/controllers/practiceGapObjects/updatePracticeGapObject.ts
@@ -7,9 +7,14 @@ import {
 
 export const updatePracticeGapObject = async (practiceGapObject: object) => {
   await dbConnect();
+
+  // get the original practice gap object
   let practiceGapObjectId = practiceGapObject['id'];
   let originalPracticeGapObject =
     await PracticeGapObjectModel.findById(practiceGapObjectId);
+
+  // update the practice gap object
+  // upsert: create a document if it doesn't exist
   let updatedPracticeGapObject = await PracticeGapObjectModel.findByIdAndUpdate(
     practiceGapObjectId,
     practiceGapObject,

--- a/lib/helperFns.ts
+++ b/lib/helperFns.ts
@@ -17,8 +17,7 @@ export const longDate = (
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
-    second: includeSeconds ? 'numeric' : undefined,
-    timeZone: timezone
+    second: includeSeconds ? 'numeric' : undefined
   });
 };
 
@@ -32,8 +31,7 @@ export const shortDate = (date: Date, timezone: string = 'America/Chicago') => {
     weekday: 'short',
     year: 'numeric',
     month: 'short',
-    day: 'numeric',
-    timeZone: timezone
+    day: 'numeric'
   });
 };
 
@@ -45,11 +43,12 @@ export const shortDate = (date: Date, timezone: string = 'America/Chicago') => {
 export const serializeDates = (object) => {
   return {
     ...object,
-    date: typeof object.date === 'string' ? object.date : longDate(object.date),
+    date:
+      typeof object.date === 'string' ? object.date : object.date.toISOString(),
     lastUpdated:
       typeof object.lastUpdated === 'string'
         ? object.lastUpdated
-        : longDate(object.lastUpdated)
+        : object.lastUpdated.toISOString()
   };
 };
 

--- a/pages/api/issues/index.ts
+++ b/pages/api/issues/index.ts
@@ -208,7 +208,7 @@ export default async function handler(
             let postSigScript = createPostSigMessage(
               noteInfo.id,
               noteInfo.project,
-              new Date(noteInfo.sigDate),
+              new Date(noteInfo.sigDate).toISOString(),
               practiceAgents,
               orgObjs
             );

--- a/pages/soap-notes/[id].tsx
+++ b/pages/soap-notes/[id].tsx
@@ -61,6 +61,17 @@ export default function CAPNote({
   // hold a ref that checks if first load
   const firstLoad = useRef(true);
 
+  // on first load, set the dates for noteInfo to be localized to the timezone
+  useEffect(() => {
+    setNoteInfo((prevNoteInfo) => ({
+      ...prevNoteInfo,
+      sigDate: shortDate(new Date(prevNoteInfo.sigDate)),
+      lastUpdated: longDate(new Date(prevNoteInfo.lastUpdated))
+    }));
+
+    setLastUpdated(longDate(new Date(noteInfo.lastUpdated)));
+  }, []);
+
   // listen for changes in pastIssue, currentIssue, or practiceGaps states and do debounced saves to database
   useEffect(() => {
     // don't save on first load
@@ -79,10 +90,10 @@ export default function CAPNote({
         return structuredClone({
           id: issue.id,
           title: issue.title,
-          date: issue.date,
+          date: new Date(issue.date).toISOString(),
           project: issue.project,
           sig: issue.sig,
-          lastUpdated: issue.lastUpdated,
+          lastUpdated: new Date(issue.lastUpdated).toISOString(),
           wasDeleted: issue.wasDeleted,
           wasMerged: issue.wasMerged,
           mergeTarget: issue.mergeTarget,
@@ -93,14 +104,15 @@ export default function CAPNote({
           priorInstances: issue.priorInstances
         });
       });
+
       let currentIssuesToSave = currentIssuesData.map((issue) => {
         return structuredClone({
           id: issue.id,
           title: issue.title,
-          date: issue.date,
+          date: new Date(issue.date).toISOString(),
           project: issue.project,
           sig: issue.sig,
-          lastUpdated: issue.lastUpdated,
+          lastUpdated: new Date(issue.lastUpdated).toISOString(),
           wasDeleted: issue.wasDeleted,
           wasMerged: issue.wasMerged,
           mergeTarget: issue.mergeTarget,
@@ -113,6 +125,11 @@ export default function CAPNote({
       });
 
       // make request to save the data to the database
+      let noteInfoWithUtc = {
+        ...noteInfo,
+        sigDate: new Date(noteInfo.sigDate).toISOString(),
+        lastUpdated: new Date(noteInfo.lastUpdated).toISOString()
+      };
       try {
         // make one request to save the past issues
         const pastIssueRes = await fetch(`/api/issues/`, {
@@ -120,7 +137,7 @@ export default function CAPNote({
           body: JSON.stringify({
             data: [...pastIssuesToSave],
             updateType: 'past',
-            noteInfo: noteInfo
+            noteInfo: noteInfoWithUtc
           }),
           headers: {
             'Content-Type': 'application/json'
@@ -146,7 +163,7 @@ export default function CAPNote({
           body: JSON.stringify({
             data: [...currentIssuesToSave],
             updateType: 'current',
-            noteInfo: noteInfo
+            noteInfo: noteInfoWithUtc
           }),
           headers: {
             'Content-Type': 'application/json'
@@ -173,7 +190,7 @@ export default function CAPNote({
           return structuredClone({
             id: practiceGap.id,
             title: practiceGap.title,
-            date: practiceGap.date,
+            date: new Date(practiceGap.date).toISOString(),
             project: practiceGap.project,
             sig: practiceGap.sig,
             description: practiceGap.description,
@@ -212,12 +229,12 @@ export default function CAPNote({
          * Finally, update and save noteInfo
          */
         // hold a last updated timestamp
-        const lastUpdated = new Date();
+        const lastUpdated = new Date().toISOString();
 
         // create a clone of the data to save
         let dataToSave = structuredClone({
           project: noteInfo.project,
-          date: noteInfo.sigDate,
+          date: new Date(noteInfo.sigDate).toISOString(),
           lastUpdated: lastUpdated,
           sigName: noteInfo.sigName,
           sigAbbreviation: noteInfo.sigAbbreviation,
@@ -254,7 +271,7 @@ export default function CAPNote({
         }
 
         // update the last updated timestamp for the note
-        setLastUpdated(longDate(lastUpdated, true));
+        setLastUpdated(longDate(new Date(lastUpdated), true));
 
         // update the state variable for noteInfo
         setNoteInfo((prevNoteInfo) => ({
@@ -393,7 +410,7 @@ export default function CAPNote({
                           key={`issue-card-${lastWeekIssue.id}`}
                           issueId={lastWeekIssue.id}
                           title={lastWeekIssue.title}
-                          date={lastWeekIssue.date}
+                          date={new Date(lastWeekIssue.date).toISOString()}
                           selectedIssue={selectedIssue}
                           setSelectedIssue={setSelectedIssue}
                           pastIssuesData={pastIssuesData}
@@ -413,7 +430,7 @@ export default function CAPNote({
                             key={`issue-card-${currIssue.id}`}
                             project={noteInfo.project}
                             sig={noteInfo.sigName}
-                            date={noteInfo.sigDate}
+                            date={new Date(noteInfo.sigDate).toISOString()}
                             issueId={currIssue.id}
                             issue={currIssue}
                             selectedIssue={selectedIssue}
@@ -430,7 +447,7 @@ export default function CAPNote({
                         key="issue-card-add-issue"
                         project={noteInfo.project}
                         sig={noteInfo.sigName}
-                        date={noteInfo.sigDate}
+                        date={new Date(noteInfo.sigDate).toISOString()}
                         issueId="add-issue"
                         issue={null}
                         selectedIssue={selectedIssue}
@@ -478,7 +495,7 @@ export default function CAPNote({
                             key={`issue-card-${practiceGap.id}`}
                             project={noteInfo.project}
                             sig={noteInfo.sigName}
-                            date={noteInfo.sigDate}
+                            date={new Date(noteInfo.sigDate).toISOString()}
                             practiceGapId={practiceGap.id}
                             practiceGap={practiceGap}
                             practiceGapsData={practiceGapData}
@@ -495,7 +512,7 @@ export default function CAPNote({
                         key="issue-card-add-practice"
                         project={noteInfo.project}
                         sig={noteInfo.sigName}
-                        date={noteInfo.sigDate}
+                        date={new Date(noteInfo.sigDate).toISOString()}
                         practiceGapId="add-practice"
                         practiceGap={null}
                         practiceGapsData={practiceGapData}
@@ -549,7 +566,7 @@ export default function CAPNote({
                         issueId={selectedIssue}
                         project={noteInfo.project}
                         sig={noteInfo.sigName}
-                        date={noteInfo.sigDate}
+                        date={new Date(noteInfo.sigDate).toISOString()}
                         currentIssuesData={currentIssuesData}
                         setCurrentIssuesData={setCurrentIssuesData}
                         practiceGapData={practiceGapData}
@@ -633,14 +650,20 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
    */
   // TODO: see how I can add type checking to this
   let currentCAPNote = await fetchCAPNote(sigAbbrev, project, date);
-  let currentCAPNoteFlattened = currentCAPNote.toJSON(mongoIdFlattener);
+  let currentCAPNoteFlattened = serializeDates(
+    currentCAPNote.toJSON(mongoIdFlattener)
+  );
 
   // get the issues for the current note
   let pastIssues = await fetchIssueObjectsByIds(
     currentCAPNote.pastIssues.map((issue) => issue._id)
   );
   let pastIssuesFlattened = pastIssues.map((issue) => {
-    return serializeDates(issue.toJSON(mongoIdFlattener));
+    let flattenedData = serializeDates(issue.toJSON(mongoIdFlattener));
+    flattenedData.priorInstances = issue.priorInstances.map((instance) => {
+      return instance.toString();
+    });
+    return flattenedData;
   });
 
   let currentIssues = await fetchIssueObjectsByIds(
@@ -671,7 +694,11 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
         trackedPractice.prevIssues.map((issue) => issue._id)
       )
     ).map((issue) => {
-      return serializeDates(issue.toJSON(mongoIdFlattener));
+      let flattenedData = serializeDates(issue.toJSON(mongoIdFlattener));
+      flattenedData.priorInstances = issue.priorInstances.map((instance) => {
+        return instance.toString();
+      });
+      return flattenedData;
     });
   }
 
@@ -681,8 +708,8 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
     project: currentCAPNoteFlattened.project,
     sigName: currentCAPNoteFlattened.sigName,
     sigAbbreviation: currentCAPNoteFlattened.sigAbbreviation,
-    sigDate: longDate(currentCAPNoteFlattened.date, true),
-    lastUpdated: longDate(currentCAPNoteFlattened.lastUpdated, true),
+    sigDate: currentCAPNoteFlattened.date,
+    lastUpdated: currentCAPNoteFlattened.lastUpdated,
     context: currentCAPNoteFlattened.context,
     assessment: currentCAPNoteFlattened.assessment,
     plan: currentCAPNoteFlattened.plan,

--- a/pages/soap-notes/[id].tsx
+++ b/pages/soap-notes/[id].tsx
@@ -824,53 +824,17 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
   const currentWeekIssues = currentIssuesFlattened;
   const practiceGaps = trackedPracticesFlattened;
 
-  // setup triggers and options for each section's text boxes
-  // TODO: have controllers that abstract this
-  const autocompleteTriggersOptions = {
-    summary: {},
-    context: {},
-    subjective: {},
-    objective: {},
-    assessment: {},
-    plan: {
-      // '[practice]': [
-      //   ' morning of office hours: ',
-      //   ' at office hours: ',
-      //   ' after SIG: ',
-      //   ' day after SIG: ',
-      //   ' morning of next SIG: ',
-      //   ' at next SIG: ',
-      //   ' morning of studio: ',
-      //   ' at studio: ',
-      //   ' after studio: '
-      // ],
-      // '[follow-up]': [' follow-up template at next SIG meeting']
-      // TODO: what are other kinds of self-regulation strategies / buckets
-      '[': ['plan]: ', 'help]: ', 'reflect]: ', 'self-work]: '],
-      'w/': ['mentor', 'peer', 'self'],
-      'rep/': [
-        'problem statement',
-        'design argument',
-        'interface argument',
-        'system argument',
-        'user testing plan',
-        'testing takeaways',
-        'approach tree',
-        'sketch a journey map / storyboard',
-        '', // empty string for no representation
-        'write: ',
-        'reflect on: '
-      ],
-      '@': ['mysore', 'pair research', 'office hours', 'sig']
-    }
-  };
-
-  // print before returning
-  console.log('capNoteInfo', JSON.stringify(capNoteInfo, null, 2));
-  console.log('lastWeekIssues', JSON.stringify(lastWeekIssues, null, 2));
-  console.log('currentWeekIssues', JSON.stringify(currentWeekIssues, null, 2));
-  console.log('practiceGaps', JSON.stringify(practiceGaps, null, 2));
-  console.log('autocompleteTriggersOptions', autocompleteTriggersOptions);
+  // print before returning if in development
+  const env = process.env.NODE_ENV;
+  if (env == 'development') {
+    console.log('capNoteInfo', JSON.stringify(capNoteInfo, null, 2));
+    console.log('lastWeekIssues', JSON.stringify(lastWeekIssues, null, 2));
+    console.log(
+      'currentWeekIssues',
+      JSON.stringify(currentWeekIssues, null, 2)
+    );
+    console.log('practiceGaps', JSON.stringify(practiceGaps, null, 2));
+  }
 
   return {
     props: {

--- a/pages/soap-notes/[id].tsx
+++ b/pages/soap-notes/[id].tsx
@@ -386,7 +386,7 @@ export default function CAPNote({
                     </p>
 
                     {/* Issues */}
-                    <div className="grid grid-cols-8 gap-2">
+                    <div className="grid grid-cols-6 gap-2">
                       {/* Last Week Issues */}
                       {pastIssuesData.map((lastWeekIssue) => (
                         <LastWeekIssueCard

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,6 +18,8 @@ body {
 .react-autocomplete-input {
   font-size: 12px !important;
   margin-top: 0.5em !important;
+  /* grid: 1fr 1fr !important; */
+  todo: see if I can show this together;
 }
 
 .react-autocomplete-input > li {


### PR DESCRIPTION
This PR makes small readability changes, attempts to only use utc timestamps everywhere (minus where local formatting is needed) #69 #70; and combines the saving of issues, practice gaps, and note into into a single use effect.