### PR TITLE
Weekly autopopulation of SIG meetings

### DIFF
--- a/controllers/capNotes/createSoapNote.ts
+++ b/controllers/capNotes/createSoapNote.ts
@@ -11,6 +11,25 @@ import { createNewTextEntryBlock } from '../textEntryBlock/createNewTextEntryBlo
  */
 export const createCAPNote = async (projectName: string, noteDate: Date) => {
   try {
+    await dbConnect();
+
+    const normalizedDate = new Date(
+      Date.UTC(
+        noteDate.getUTCFullYear(),
+        noteDate.getUTCMonth(),
+        noteDate.getUTCDate()
+      )
+    );
+
+    const existingCAPNote = await CAPNoteModel.findOne({
+      project: projectName,
+      date: normalizedDate
+    });
+
+    if (existingCAPNote) {
+      return existingCAPNote;
+    }
+
     // get proj and sig info
     const projInfoRes = await fetch(
       `${process.env.STUDIO_API}/projects/byName?${new URLSearchParams({
@@ -34,7 +53,6 @@ export const createCAPNote = async (projectName: string, noteDate: Date) => {
     ).abbreviation;
 
     // get the previous CAP note for the project
-    await dbConnect();
     const previousCAPNotes = await CAPNoteModel.find({
       project: projectName,
       sigName: sigName
@@ -59,11 +77,10 @@ export const createCAPNote = async (projectName: string, noteDate: Date) => {
     }
 
     // save the new SOAP note to the database
-    await dbConnect();
     return await CAPNoteModel.create({
       project: projectName,
-      date: noteDate,
-      lastUpdated: noteDate,
+      date: normalizedDate,
+      lastUpdated: normalizedDate,
       sigName: sigName,
       sigAbbreviation: sigAbbreviation,
       context: [createNewTextEntryBlock()],

--- a/lib/helperFns.ts
+++ b/lib/helperFns.ts
@@ -54,29 +54,20 @@ export const shortDateFromISO = (isoString: string): string => {
 };
 
 /**
- * Formats an ISO date string to long form without timezone conversion.
- * Extracts the date portion directly to avoid UTC-to-local timezone shifts.
- * @param isoString ISO date string (e.g., "2026-04-07T10:30:00.000Z")
- * @param includeSeconds whether to include seconds
- * @returns string formatted date
+ * Converts a date-only display string back to a stable ISO date at UTC midnight.
+ * This avoids shifting the stored SIG day when users in different timezones save edits.
+ * @param dateString human-readable date string (e.g. "Wed, Apr 22, 2026")
+ * @returns ISO string at UTC midnight for that calendar day
  */
-export const longDateFromISO = (isoString: string, includeSeconds: boolean = false): string => {
-  // Extract date and time from ISO string
-  const [datePart, timePart] = isoString.split('T');
-  const [year, month, day] = datePart.split('-').map(Number);
-  const [hours, minutes, secondsStr] = timePart.split(':');
-  const seconds = parseInt(secondsStr);
-  
-  const date = new Date(year, month - 1, day, parseInt(hours), parseInt(minutes), seconds);
-  return date.toLocaleDateString('en-us', {
-    weekday: 'short',
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: includeSeconds ? 'numeric' : undefined
-  });
+export const serializeDateOnlyToISO = (dateString: string): string => {
+  const parsedDate = new Date(dateString);
+  return new Date(
+    Date.UTC(
+      parsedDate.getFullYear(),
+      parsedDate.getMonth(),
+      parsedDate.getDate()
+    )
+  ).toISOString();
 };
 
 /**

--- a/lib/server/sigAutopopulate.ts
+++ b/lib/server/sigAutopopulate.ts
@@ -1,0 +1,238 @@
+import CAPNoteModel from '../../models/CAPNoteModel';
+import { createCAPNote } from '../../controllers/capNotes/createSoapNote';
+import dbConnect from '../dbConnect';
+
+type SIGVenue = {
+  name?: string;
+  day_of_week?: string;
+  projects?: Array<string | { name?: string }>;
+};
+
+type SprintProcess = {
+  name?: string;
+  start_day?: string;
+  end_day?: string;
+};
+
+type ParsedSprint = {
+  sprintNumber: number;
+  startDay: Date;
+  endDay: Date;
+};
+
+const fetchJson = async (url: string) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+const normalizeDateToUtcMidnight = (date: Date) => {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+};
+
+const getTimezoneDateAtUtcMidnight = (date: Date, timezone: string) => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  }).formatToParts(date);
+
+  const year = Number(parts.find((part) => part.type === 'year')?.value);
+  const month = Number(parts.find((part) => part.type === 'month')?.value);
+  const day = Number(parts.find((part) => part.type === 'day')?.value);
+
+  return new Date(Date.UTC(year, month - 1, day));
+};
+
+const weekdayToUtcIndex: Record<string, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6
+};
+
+const startOfIsoWeek = (date: Date) => {
+  const normalizedDate = normalizeDateToUtcMidnight(date);
+  const utcDay = normalizedDate.getUTCDay();
+  const daysFromMonday = utcDay === 0 ? 6 : utcDay - 1;
+  normalizedDate.setUTCDate(normalizedDate.getUTCDate() - daysFromMonday);
+  return normalizedDate;
+};
+
+const weekKey = (date: Date) => startOfIsoWeek(date).toISOString();
+
+const getVenueDateInWeek = (weekStart: Date, weekday: string) => {
+  const targetUtcDay = weekdayToUtcIndex[weekday];
+  if (targetUtcDay === undefined) {
+    return null;
+  }
+
+  const mondayStart = startOfIsoWeek(weekStart);
+  const dayOffset = targetUtcDay === 0 ? 6 : targetUtcDay - 1;
+  mondayStart.setUTCDate(mondayStart.getUTCDate() + dayOffset);
+  return mondayStart;
+};
+
+const fetchSIGVenues = async () => {
+  if (!process.env.STUDIO_API) {
+    return [];
+  }
+
+  const venues = await fetchJson(`${process.env.STUDIO_API}/venues/sig`);
+  return Array.isArray(venues) ? venues : [];
+};
+
+const fetchSprints = async () => {
+  if (!process.env.STUDIO_API) {
+    return [];
+  }
+
+  const sprints = await fetchJson(`${process.env.STUDIO_API}/sprints`);
+  return Array.isArray(sprints) ? sprints : [];
+};
+
+const getQuarterBounds = (sprints: SprintProcess[]) => {
+  const sprintEntries = sprints
+    .map<ParsedSprint | null>((sprint) => {
+      const match = sprint?.name?.match(/^Sprint (\d+)$/);
+      if (!match || match[1] === '0' || !sprint.start_day || !sprint.end_day) {
+        return null;
+      }
+
+      const sprintNumber = Number(match[1]);
+      const startDay = new Date(sprint.start_day);
+      const endDay = new Date(sprint.end_day);
+      if (
+        Number.isNaN(startDay.getTime()) ||
+        Number.isNaN(endDay.getTime())
+      ) {
+        return null;
+      }
+
+      return {
+        sprintNumber,
+        startDay: normalizeDateToUtcMidnight(startDay),
+        endDay: normalizeDateToUtcMidnight(endDay)
+      };
+    })
+    .filter((sprint): sprint is ParsedSprint => sprint !== null)
+    .sort((a, b) => a.sprintNumber - b.sprintNumber);
+
+  if (sprintEntries.length === 0) {
+    return null;
+  }
+
+  return {
+    quarterStart: sprintEntries[0].startDay,
+    quarterEnd: sprintEntries[sprintEntries.length - 1].endDay
+  };
+};
+
+const getTargetWeekStart = (
+  quarterStart: Date,
+  quarterEnd: Date
+) => {
+  const todayInChicago = getTimezoneDateAtUtcMidnight(
+    new Date(),
+    'America/Chicago'
+  );
+
+  if (todayInChicago < quarterStart || todayInChicago > quarterEnd) {
+    return null;
+  }
+
+  return startOfIsoWeek(todayInChicago);
+};
+
+export const ensureWeeklyCAPNotesExist = async () => {
+  const [sigVenues, sprints] = await Promise.all([fetchSIGVenues(), fetchSprints()]);
+  if (sigVenues.length === 0 || sprints.length === 0) {
+    return { createdCount: 0 };
+  }
+
+  const quarterBounds = getQuarterBounds(sprints);
+  if (!quarterBounds) {
+    return { createdCount: 0 };
+  }
+
+  const targetWeekStart = getTargetWeekStart(
+    quarterBounds.quarterStart,
+    quarterBounds.quarterEnd
+  );
+
+  if (!targetWeekStart) {
+    return { createdCount: 0 };
+  }
+
+  await dbConnect();
+
+  const allProjects = sigVenues.flatMap((venue) =>
+    Array.isArray(venue.projects)
+      ? venue.projects
+          .map((project) =>
+            typeof project === 'string' ? project : project?.name ?? null
+          )
+          .filter((projectName): projectName is string => Boolean(projectName))
+      : []
+  );
+
+  const existingNotes = await CAPNoteModel.find({
+    project: { $in: allProjects }
+  }).select({ project: 1, date: 1 });
+
+  const existingNoteKeys = new Set(
+    existingNotes.map((note) => `${note.project}::${weekKey(new Date(note.date))}`)
+  );
+
+  let createdCount = 0;
+
+  for (const venue of sigVenues) {
+    if (
+      !venue?.day_of_week ||
+      !Array.isArray(venue.projects) ||
+      venue.projects.length === 0
+    ) {
+      continue;
+    }
+
+    const noteDate = getVenueDateInWeek(targetWeekStart, venue.day_of_week);
+    if (
+      !noteDate ||
+      noteDate < quarterBounds.quarterStart ||
+      noteDate > quarterBounds.quarterEnd
+    ) {
+      continue;
+    }
+
+    for (const projectRef of venue.projects) {
+      const projectName =
+        typeof projectRef === 'string' ? projectRef : projectRef?.name ?? null;
+
+      if (!projectName) {
+        continue;
+      }
+
+      const noteKey = `${projectName}::${weekKey(noteDate)}`;
+      if (existingNoteKeys.has(noteKey)) {
+        continue;
+      }
+
+      const createdNote = await createCAPNote(projectName, noteDate);
+      if (createdNote) {
+        existingNoteKeys.add(noteKey);
+        createdCount += 1;
+      }
+    }
+  }
+
+  return { createdCount };
+};

--- a/pages/cap-notes/[id].tsx
+++ b/pages/cap-notes/[id].tsx
@@ -14,8 +14,9 @@ import { HTML5Backend } from 'react-dnd-html5-backend';
 // utilities
 import {
   longDate,
+  serializeDateOnlyToISO,
   serializeDates,
-  shortDate,
+  shortDateFromISO,
   shortenText
 } from '../../lib/helperFns';
 
@@ -43,9 +44,20 @@ export default function CAPNote({
   currentWeekIssues,
   practiceGaps
 }): JSX.Element {
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+
   // have state for cap note data
   const [noteInfo, setNoteInfo] = useState(capNoteInfo);
   const [lastUpdated, setLastUpdated] = useState(capNoteInfo.lastUpdated);
+  const [meetingTranscript, setMeetingTranscript] = useState(
+    capNoteInfo.meetingTranscript ?? null
+  );
+  const [isRecording, setIsRecording] = useState(false);
+  const [isUploadingRecording, setIsUploadingRecording] = useState(false);
+  const [transcriptError, setTranscriptError] = useState<string | null>(null);
+  const [expectedSpeakers, setExpectedSpeakers] = useState(2);
 
   // hold data state for issues and practices
   // see here for updating arrays in state variables: https://react.dev/learn/updating-arrays-in-state#updating-objects-inside-arrays
@@ -70,12 +82,161 @@ export default function CAPNote({
   useEffect(() => {
     setNoteInfo((prevNoteInfo) => ({
       ...prevNoteInfo,
-      sigDate: shortDate(new Date(prevNoteInfo.sigDate)),
+      sigDate: shortDateFromISO(prevNoteInfo.sigDate),
       lastUpdated: longDate(new Date(prevNoteInfo.lastUpdated))
     }));
 
     setLastUpdated(longDate(new Date(noteInfo.lastUpdated)));
   }, []);
+
+  useEffect(() => {
+    if (meetingTranscript?.status !== 'processing') {
+      return;
+    }
+
+    const intervalId = setInterval(async () => {
+      try {
+        const transcriptRes = await fetch(`/api/transcripts/${noteInfo.id}`);
+        const transcriptData = await transcriptRes.json();
+
+        if (!transcriptRes.ok) {
+          throw new Error(
+            transcriptData.error ?? 'Unable to refresh transcript status'
+          );
+        }
+
+        setMeetingTranscript(transcriptData.data);
+        if (transcriptData.data?.status === 'error') {
+          setTranscriptError(
+            transcriptData.data.error ?? 'Transcription processing failed'
+          );
+        }
+      } catch (error) {
+        console.error(error);
+        setTranscriptError(
+          error instanceof Error
+            ? error.message
+            : 'Unable to refresh transcript status'
+        );
+      }
+    }, 5000);
+
+    return () => clearInterval(intervalId);
+  }, [meetingTranscript?.status, noteInfo.id]);
+
+  useEffect(() => {
+    return () => {
+      mediaRecorderRef.current?.stream
+        ?.getTracks()
+        .forEach((track) => track.stop());
+      mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+    };
+  }, []);
+
+  const startRecording = async () => {
+    try {
+      setTranscriptError(null);
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaStreamRef.current = stream;
+      audioChunksRef.current = [];
+
+      const preferredMimeType = [
+        'audio/webm;codecs=opus',
+        'audio/webm',
+        'audio/mp4'
+      ].find((mimeType) => MediaRecorder.isTypeSupported(mimeType));
+
+      const recorder = new MediaRecorder(stream, {
+        mimeType: preferredMimeType,
+        audioBitsPerSecond: 128000
+      });
+      mediaRecorderRef.current = recorder;
+
+      recorder.addEventListener('dataavailable', (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      });
+
+      recorder.addEventListener('stop', async () => {
+        const audioBlob = new Blob(audioChunksRef.current, {
+          type: recorder.mimeType || 'audio/webm'
+        });
+        stream.getTracks().forEach((track) => track.stop());
+        mediaStreamRef.current = null;
+        setIsUploadingRecording(true);
+
+        try {
+          const transcriptRes = await fetch(`/api/transcripts/${noteInfo.id}`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': audioBlob.type,
+              'x-expected-speakers': expectedSpeakers.toString()
+            },
+            body: audioBlob
+          });
+          const transcriptData = await transcriptRes.json();
+
+          if (!transcriptRes.ok) {
+            throw new Error(
+              transcriptData.error ?? 'Unable to start transcription'
+            );
+          }
+
+          setMeetingTranscript(transcriptData.data);
+        } catch (error) {
+          console.error(error);
+          setTranscriptError(
+            error instanceof Error
+              ? error.message
+              : 'Unable to upload meeting recording'
+          );
+        } finally {
+          setIsUploadingRecording(false);
+          mediaRecorderRef.current = null;
+        }
+      });
+
+      recorder.start(1000);
+      setIsRecording(true);
+    } catch (error) {
+      console.error(error);
+      setTranscriptError(
+        error instanceof Error
+          ? error.message
+          : 'Unable to access microphone for recording'
+      );
+    }
+  };
+
+  const stopRecording = () => {
+    if (!mediaRecorderRef.current || mediaRecorderRef.current.state === 'inactive') {
+      return;
+    }
+
+    mediaRecorderRef.current.requestData();
+    mediaRecorderRef.current.stop();
+    setIsRecording(false);
+  };
+
+  const refreshTranscript = async () => {
+    try {
+      setTranscriptError(null);
+      const transcriptRes = await fetch(`/api/transcripts/${noteInfo.id}`);
+      const transcriptData = await transcriptRes.json();
+
+      if (!transcriptRes.ok) {
+        throw new Error(transcriptData.error ?? 'Unable to fetch transcript');
+      }
+
+      setMeetingTranscript(transcriptData.data);
+    } catch (error) {
+      console.error(error);
+      setTranscriptError(
+        error instanceof Error ? error.message : 'Unable to fetch transcript'
+      );
+    }
+  };
 
   // listen for changes in pastIssue, currentIssue, or practiceGaps states and do debounced saves to database
   useEffect(() => {
@@ -132,7 +293,7 @@ export default function CAPNote({
       // make request to save the data to the database
       let noteInfoWithUtc = {
         ...noteInfo,
-        sigDate: new Date(noteInfo.sigDate).toISOString(),
+        sigDate: serializeDateOnlyToISO(noteInfo.sigDate),
         lastUpdated: new Date(noteInfo.lastUpdated).toISOString()
       };
       try {
@@ -239,7 +400,7 @@ export default function CAPNote({
         // create a clone of the data to save
         let dataToSave = structuredClone({
           project: noteInfo.project,
-          date: new Date(noteInfo.sigDate).toISOString(),
+          date: serializeDateOnlyToISO(noteInfo.sigDate),
           lastUpdated: lastUpdated,
           sigName: noteInfo.sigName,
           sigAbbreviation: noteInfo.sigAbbreviation,
@@ -312,7 +473,7 @@ export default function CAPNote({
           {`${shortenText(
             noteInfo.project,
             15
-          )} | ${new Date(noteInfo.sigDate).toLocaleString().split(',')[0]}`}
+          )} | ${noteInfo.sigDate}`}
         </title>
       </Head>
 
@@ -382,6 +543,95 @@ export default function CAPNote({
           <div></div>
         </div>
 
+        <div className="mb-4 mt-3 rounded border border-slate-300 bg-slate-50 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-base font-bold">Meeting Recording</h2>
+              <p className="text-sm text-slate-600">
+                Record the project team meeting, then process a speaker-labeled
+                transcript for coach review and future LLM use.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <label className="flex items-center gap-2 rounded-full border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700">
+                <span>Expected Speakers</span>
+                <select
+                  value={expectedSpeakers}
+                  onChange={(e) => setExpectedSpeakers(Number(e.target.value))}
+                  className="bg-transparent outline-none"
+                  disabled={isRecording || isUploadingRecording}
+                >
+                  {[2, 3, 4, 5, 6].map((count) => (
+                    <option key={count} value={count}>
+                      {count}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {!isRecording ? (
+                <button
+                  className="rounded-full bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:opacity-50"
+                  onClick={startRecording}
+                  disabled={isUploadingRecording}
+                >
+                  Start Recording
+                </button>
+              ) : (
+                <button
+                  className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700"
+                  onClick={stopRecording}
+                >
+                  Stop & Process
+                </button>
+              )}
+              <button
+                className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+                onClick={refreshTranscript}
+              >
+                Refresh Transcript
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-3 text-sm text-slate-700">
+            {isRecording && <p>Recording in progress. Click stop when the meeting ends.</p>}
+            {isUploadingRecording && (
+              <p>Uploading audio and starting transcription...</p>
+            )}
+            {!isUploadingRecording && meetingTranscript?.status === 'processing' && (
+              <p>
+                Transcript is processing with {meetingTranscript.provider}. This
+                panel refreshes automatically every few seconds.
+              </p>
+            )}
+            {meetingTranscript?.status === 'completed' && (
+              <p>
+                Transcript ready
+                {meetingTranscript.completedAt
+                  ? ` • Completed ${meetingTranscript.completedAt}`
+                  : ''}
+              </p>
+            )}
+            {transcriptError && (
+              <p className="font-semibold text-red-600">{transcriptError}</p>
+            )}
+          </div>
+
+          {meetingTranscript?.formattedText && (
+            <div className="mt-4 rounded border border-slate-200 bg-white p-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <h3 className="text-sm font-bold">Transcript</h3>
+                <div className="text-xs text-slate-500">
+                  {meetingTranscript.utterances?.length ?? 0} speaker turns
+                </div>
+              </div>
+              <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-sm leading-6 text-slate-800">
+                {meetingTranscript.formattedText}
+              </pre>
+            </div>
+          )}
+        </div>
+
         <DndProvider backend={HTML5Backend}>
           {/* Past issues and tracked practices fixed to top of page */}
           {/* TODO: 05-06-24: maybe add a hide and show button so mentor can recover vertical space when done browsing past issues */}
@@ -414,7 +664,7 @@ export default function CAPNote({
                           issueId={lastWeekIssue.id}
                           title={lastWeekIssue.title}
                           date={new Date(lastWeekIssue.date).toISOString()}
-                          noteDate={new Date(noteInfo.sigDate).toISOString()}
+                          noteDate={serializeDateOnlyToISO(noteInfo.sigDate)}
                           selectedIssue={selectedIssue}
                           setSelectedIssue={setSelectedIssue}
                           pastIssuesData={pastIssuesData}
@@ -434,7 +684,7 @@ export default function CAPNote({
                             key={`issue-card-${currIssue.id}`}
                             project={noteInfo.project}
                             sig={noteInfo.sigName}
-                            date={new Date(noteInfo.sigDate).toISOString()}
+                            date={serializeDateOnlyToISO(noteInfo.sigDate)}
                             issueId={currIssue.id}
                             issue={currIssue}
                             selectedIssue={selectedIssue}
@@ -451,7 +701,7 @@ export default function CAPNote({
                         key="issue-card-add-issue"
                         project={noteInfo.project}
                         sig={noteInfo.sigName}
-                        date={new Date(noteInfo.sigDate).toISOString()}
+                        date={serializeDateOnlyToISO(noteInfo.sigDate)}
                         issueId="add-issue"
                         issue={null}
                         selectedIssue={selectedIssue}
@@ -499,7 +749,7 @@ export default function CAPNote({
                             key={`issue-card-${practiceGap.id}`}
                             project={noteInfo.project}
                             sig={noteInfo.sigName}
-                            date={new Date(noteInfo.sigDate).toISOString()}
+                            date={serializeDateOnlyToISO(noteInfo.sigDate)}
                             practiceGapId={practiceGap.id}
                             practiceGap={practiceGap}
                             practiceGapsData={practiceGapData}
@@ -516,7 +766,7 @@ export default function CAPNote({
                         key="issue-card-add-practice"
                         project={noteInfo.project}
                         sig={noteInfo.sigName}
-                        date={new Date(noteInfo.sigDate).toISOString()}
+                        date={serializeDateOnlyToISO(noteInfo.sigDate)}
                         practiceGapId="add-practice"
                         practiceGap={null}
                         practiceGapsData={practiceGapData}
@@ -570,7 +820,7 @@ export default function CAPNote({
                         issueId={selectedIssue}
                         project={noteInfo.project}
                         sig={noteInfo.sigName}
-                        date={new Date(noteInfo.sigDate).toISOString()}
+                        date={serializeDateOnlyToISO(noteInfo.sigDate)}
                         currentIssuesData={currentIssuesData}
                         setCurrentIssuesData={setCurrentIssuesData}
                         practiceGapData={practiceGapData}
@@ -624,8 +874,10 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
   // helper function to convert mongo ids to strings
   const mongoIdFlattener = {
     transform: function (doc, ret) {
-      ret.id = ret._id.toString();
-      delete ret._id;
+      if (ret?._id !== undefined && ret?._id !== null) {
+        ret.id = ret._id.toString();
+        delete ret._id;
+      }
     }
   };
 
@@ -727,7 +979,8 @@ export const getServerSideProps: GetServerSideProps = async (query) => {
       (practice) => {
         return practice.toString();
       }
-    )
+    ),
+    meetingTranscript: currentCAPNoteFlattened.meetingTranscript ?? null
   };
 
   /**

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { fetchAllCAPNotes } from '../controllers/capNotes/fetchCAPNotes';
 import Head from 'next/head';
-import { longDate, shortDate, longDateFromISO, shortDateFromISO } from '../lib/helperFns';
+import { longDate, shortDate, shortDateFromISO } from '../lib/helperFns';
 import { useEffect, useState } from 'react';
 
 export default function Home({ sigs }): JSX.Element {
@@ -38,7 +38,7 @@ export default function Home({ sigs }): JSX.Element {
           .map((capNote) => ({
             ...capNote,
             dateDisplay: shortDateFromISO(capNote.date),
-            lastUpdatedDisplay: longDateFromISO(capNote.lastUpdated)
+            lastUpdatedDisplay: longDate(new Date(capNote.lastUpdated))
           }))
           .sort((a, b) => new Date(b.date) - new Date(a.date)) // Sort newest first by ISO date
       }))
@@ -204,6 +204,11 @@ export default function Home({ sigs }): JSX.Element {
 
 // use serverside rendering to generate this page
 export const getServerSideProps = async () => {
+  const { ensureWeeklyCAPNotesExist } = await import(
+    '../lib/server/sigAutopopulate'
+  );
+  await ensureWeeklyCAPNotesExist();
+
   // fetch all CAP notes
   const capNotes = await fetchAllCAPNotes();
 

--- a/pages/reflections/[id].tsx
+++ b/pages/reflections/[id].tsx
@@ -13,7 +13,9 @@ import { Tooltip } from 'flowbite-react';
 import {
   longDate,
   serializeDates,
+  serializeDateOnlyToISO,
   shortDate,
+  shortDateFromISO,
   shortenText
 } from '../../lib/helperFns';
 
@@ -154,7 +156,7 @@ export default function CAPNote({ capNoteInfo, pastIssues }): JSX.Element {
 
     setNoteInfo((prevNoteInfo) => ({
       ...prevNoteInfo,
-      sigDate: shortDate(new Date(prevNoteInfo.sigDate)),
+      sigDate: shortDateFromISO(prevNoteInfo.sigDate),
       lastUpdated: longDate(new Date(prevNoteInfo.lastUpdated))
     }));
 
@@ -196,7 +198,7 @@ export default function CAPNote({ capNoteInfo, pastIssues }): JSX.Element {
       // make request to save the data to the database
       let noteInfoWithUtc = {
         ...noteInfo,
-        sigDate: new Date(noteInfo.sigDate).toISOString(),
+        sigDate: serializeDateOnlyToISO(noteInfo.sigDate),
         lastUpdated: new Date(noteInfo.lastUpdated).toISOString()
       };
       try {


### PR DESCRIPTION
Autopopulate weekly SIG notes and fix SIG date save drift.
- when the home page loads, the app checks whether each project team already has a CAP note for the current Chicago calendar week
- if a project does not have one, it creates that week’s SIG note automatically based on the hardcoded studio-api SIG schedule
- if a same-week note already exists, it does not create another one
- editing a CAP note or reflection no longer shifts the SIG date backward by a day