### PR TITLE
SIG Rescheduling Edge Case Fix

### DIFF
--- a/controllers/capNotes/createSoapNote.ts
+++ b/controllers/capNotes/createSoapNote.ts
@@ -3,6 +3,60 @@ import dbConnect from '../../lib/dbConnect';
 import CAPNoteModel from '../../models/CAPNoteModel';
 import IssueObjectModel from '../../models/IssueObjectModel';
 import { createNewTextEntryBlock } from '../textEntryBlock/createNewTextEntryBlock';
+import { createPreSigReflectionMessage } from '../followUpObjects/createFollowUpStrategies';
+
+const refreshPreviousNotePreSigIssue = async (
+  previousCAPNote,
+  nextCAPNoteDate: Date,
+  projectName: string
+) => {
+  if (!process.env.ORCH_ENGINE || !previousCAPNote?._id) {
+    return;
+  }
+
+  const orgObjRes = await fetch(
+    `${process.env.ORCH_ENGINE}/organizationalObjects/getComputedOrganizationalObjectsForProject`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ projectName })
+    }
+  );
+
+  if (!orgObjRes.ok) {
+    throw new Error(
+      `Could not fetch computed organizational objects for ${projectName}`
+    );
+  }
+
+  const orgObjs = await orgObjRes.json();
+  const preSigReflectionScript = createPreSigReflectionMessage(
+    previousCAPNote._id.toString(),
+    projectName,
+    previousCAPNote.date.toISOString(),
+    orgObjs,
+    nextCAPNoteDate.toISOString()
+  );
+
+  const preSigReflectionOSRes = await fetch(
+    `${process.env.ORCH_ENGINE}/activeissues/createActiveIssue`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(preSigReflectionScript)
+    }
+  );
+
+  if (!preSigReflectionOSRes.ok) {
+    throw new Error(
+      `Could not refresh pre-sig reflection for ${projectName} on ${previousCAPNote.date.toISOString()}`
+    );
+  }
+};
 
 /**
  * Create a new CAP note given the project and date of the note.
@@ -77,7 +131,7 @@ export const createCAPNote = async (projectName: string, noteDate: Date) => {
     }
 
     // save the new SOAP note to the database
-    return await CAPNoteModel.create({
+    const createdCAPNote = await CAPNoteModel.create({
       project: projectName,
       date: normalizedDate,
       lastUpdated: normalizedDate,
@@ -90,6 +144,23 @@ export const createCAPNote = async (projectName: string, noteDate: Date) => {
       currentIssues: [],
       trackedPractices: trackedPractices
     });
+
+    if (previousCAPNote) {
+      try {
+        await refreshPreviousNotePreSigIssue(
+          previousCAPNote,
+          normalizedDate,
+          projectName
+        );
+      } catch (error) {
+        console.error(
+          'Error in refreshing previous note pre-sig issue: ',
+          error
+        );
+      }
+    }
+
+    return createdCAPNote;
   } catch (err) {
     console.error('Error in creating CAP note: ', err, err.stack);
     return null;

--- a/controllers/capNotes/fetchCAPNotes.ts
+++ b/controllers/capNotes/fetchCAPNotes.ts
@@ -47,3 +47,20 @@ export const fetchCAPNoteById = async (id: string) => {
   await dbConnect();
   return await CAPNoteModel.findById(id);
 };
+
+/**
+ * Fetches the next CAP note for a project after a given date.
+ * @param project Project name
+ * @param currentDate Current CAP note date
+ * @returns next CAP note object or null
+ */
+export const fetchNextCAPNoteForProject = async (
+  project: string,
+  currentDate: Date
+) => {
+  await dbConnect();
+  return await CAPNoteModel.findOne({
+    project,
+    date: { $gt: currentDate }
+  }).sort({ date: 1 });
+};

--- a/controllers/followUpObjects/createFollowUpStrategies.ts
+++ b/controllers/followUpObjects/createFollowUpStrategies.ts
@@ -14,6 +14,94 @@ function convertTZ(date: Date | string, tzString: string) {
   );
 }
 
+const getDatePartsForTimezone = (date: Date, timezone: string) => {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23'
+  });
+
+  return formatter
+    .formatToParts(date)
+    .reduce((parts, part) => {
+      if (part.type !== 'literal') {
+        parts[part.type] = Number(part.value);
+      }
+      return parts;
+    }, {} as Record<string, number>);
+};
+
+const buildUtcDateForTimezone = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  timezone: string
+) => {
+  const utcGuess = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  const localizedParts = getDatePartsForTimezone(utcGuess, timezone);
+  const localizedUtcValue = Date.UTC(
+    localizedParts.year,
+    localizedParts.month - 1,
+    localizedParts.day,
+    localizedParts.hour,
+    localizedParts.minute,
+    localizedParts.second
+  );
+  const targetUtcValue = Date.UTC(year, month - 1, day, hour, minute, second);
+
+  return new Date(utcGuess.getTime() - (localizedUtcValue - targetUtcValue));
+};
+
+const computeExplicitPreSigOpportunity = (
+  nextSigDate: string,
+  orgObjs: any
+) => {
+  const sigVenue = orgObjs?.venues?.find((venue) => venue.kind === 'SigMeeting');
+  if (!sigVenue) {
+    return null;
+  }
+
+  const nextSigDateObj = new Date(nextSigDate);
+  if (Number.isNaN(nextSigDateObj.getTime())) {
+    return null;
+  }
+
+  const previousDay = new Date(nextSigDateObj.getTime());
+  previousDay.setUTCDate(previousDay.getUTCDate() - 1);
+
+  const [startHour, startMinute, startSecond] = sigVenue.startTime
+    .split(':')
+    .map(Number);
+
+  return buildUtcDateForTimezone(
+    previousDay.getUTCFullYear(),
+    previousDay.getUTCMonth() + 1,
+    previousDay.getUTCDate(),
+    startHour,
+    startMinute,
+    startSecond,
+    sigVenue.timezone
+  ).toISOString();
+};
+
+const computeFallbackNextSigDate = (noteDate: string) => {
+  const nextWeekDate = new Date(noteDate);
+  if (Number.isNaN(nextWeekDate.getTime())) {
+    return null;
+  }
+
+  nextWeekDate.setUTCDate(nextWeekDate.getUTCDate() + 7);
+  return nextWeekDate.toISOString();
+};
+
 /**
  * Generates a post-SIG message with all practice agents the mentor suggested for the current CAP Note.
  * @param {string} noteId - ID of the CAP note
@@ -128,7 +216,8 @@ export const createPreSigReflectionMessage = (
   noteId: string,
   projName: string,
   noteDate: string,
-  orgObjs: Object
+  orgObjs: any,
+  nextSigDate?: string | null
 ) => {
   let noteDateJS = new Date(noteDate);
   let weekFromCurrDate = new Date(noteDateJS.getTime());
@@ -161,19 +250,26 @@ export const createPreSigReflectionMessage = (
   let strategy = `You have SIG tomorrow! Please take some time to reflect on the practices your mentor suggested last week: <${reflectionUrl}|Reflection Page>.`;
   strategy = strategy.replace(/[\""]/g, '\\"');
 
-  let strategyFunction = async function () {
+  const effectiveNextSigDate = nextSigDate ?? computeFallbackNextSigDate(noteDate);
+  const explicitOpportunity = effectiveNextSigDate
+    ? computeExplicitPreSigOpportunity(effectiveNextSigDate, orgObjs)
+    : null;
+  const opportunityExpression = explicitOpportunity
+    ? `new Date('${explicitOpportunity}')`
+    : `await this.daysBeforeVenue(
+        await this.venues.find(this.where('kind', 'SigMeeting')),
+        1
+      )`;
+
+  let strategyFunction = `async function () {
     return await this.messageChannel({
       message: strategyTextToReplace,
       projectName: projectNameForNote,
       opportunity: async function () {
-        // send 1 day before the SIG meeting
-        return await this.daysBeforeVenue(
-          await this.venues.find(this.where('kind', 'SigMeeting')),
-          1
-        );
+        return ${opportunityExpression};
       }.toString()
     });
-  }.toString();
+  }`;
   strategyFunction = strategyFunction.replace(
     'projectNameForNote',
     `'${orgObjs.project.name}'`
@@ -182,7 +278,6 @@ export const createPreSigReflectionMessage = (
     'strategyTextToReplace',
     '"' + strategy + '"'
   );
-
   // add to newActiveIssue and return
   newActiveIssue.strategyToEnact.strategy_function = strategyFunction;
   return newActiveIssue;

--- a/pages/api/issues/index.ts
+++ b/pages/api/issues/index.ts
@@ -8,6 +8,7 @@ import {
   parsePracticeText,
   createPreSigReflectionMessage
 } from '../../../controllers/followUpObjects/createFollowUpStrategies';
+import { fetchNextCAPNoteForProject } from '../../../controllers/capNotes/fetchCAPNotes';
 
 type Data = {
   msg: string;
@@ -241,11 +242,16 @@ export default async function handler(
             }
 
             // Create pre-sig reflection agent
+            const nextCAPNote = await fetchNextCAPNoteForProject(
+              noteInfo.project,
+              new Date(noteInfo.sigDate)
+            );
             let preSigReflectionScript = createPreSigReflectionMessage(
               noteInfo.id,
               noteInfo.project,
               new Date(noteInfo.sigDate).toISOString(),
-              orgObjs
+              orgObjs,
+              nextCAPNote?.date?.toISOString?.() ?? null
             );
             const preSigReflectionOSRes = await fetch(
               `${process.env.ORCH_ENGINE}/activeissues/createActiveIssue`,


### PR DESCRIPTION
Handle rescheduled SIG dates for pre-SIG reminders
- On edge cases when SIGs are rescheduled from their hardcoded dates, reflections aren't sent out
- The system now handles rescheduled-week Pre SIG reminders.
- I changed interactive-soap-notes so Pre SIG scheduling uses the next real CAP note date when one exists, and otherwise defaults to current note date + 7 days instead of falling back to the generic venue weekday. 
- I also updated note creation so when a new note is created, it immediately refreshes the previous note’s Pre SIG active issue to point at that new date.