### PR TITLE
Single Reflection Box

### DIFF
--- a/models/SIGReflectionModel.ts
+++ b/models/SIGReflectionModel.ts
@@ -3,7 +3,7 @@ import mongoose from 'mongoose';
 export interface TeamReflectionStruct {
   project: string;
   capNoteId: mongoose.Types.ObjectId;
-  coachReflections: { pre: string; mid: string; post: string };
+  coachReflections: string;
   lastReflectionSavedAt: string | null;
 }
 
@@ -18,11 +18,7 @@ const TeamReflectionSchema = new mongoose.Schema<TeamReflectionStruct>(
   {
     project: { type: String, required: true },
     capNoteId: { type: mongoose.Schema.Types.ObjectId, ref: 'CAPNote', required: true },
-    coachReflections: {
-      pre: { type: String, default: '' },
-      mid: { type: String, default: '' },
-      post: { type: String, default: '' }
-    },
+    coachReflections: { type: String, default: '' },
     lastReflectionSavedAt: { type: String, default: null }
   },
   { _id: false }

--- a/pages/api/ai-draft/[id].ts
+++ b/pages/api/ai-draft/[id].ts
@@ -307,9 +307,7 @@ const buildUserMessage = (
   projectName: string,
   sigName: string,
   transcript: string,
-  reflectionsPre: string,
-  reflectionsMid: string,
-  reflectionsPost: string,
+  reflections: string,
   priorNotesText: string,
   practiceGapsText: string,
   peerCasesText: string,
@@ -336,19 +334,11 @@ const buildUserMessage = (
     msg += `## Prior CAP Notes for This Team\n\n${priorNotesText}\n\n`;
   }
 
-  if (reflectionsPre?.trim()) {
-    msg += `## Coach Pre-Meeting Reflections\n\nWritten after reviewing deliverables and student reflections, before the meeting.\n\n${reflectionsPre.trim()}\n\n`;
+  if (reflections?.trim()) {
+    msg += `## Coach Reflections\n\n${reflections.trim()}\n\n`;
   }
 
   msg += `## Meeting Transcript\n\n${transcript}\n\n`;
-
-  if (reflectionsMid?.trim()) {
-    msg += `## Coach Mid-Meeting Reflections\n\nWritten immediately after this team's turn in the SIG meeting.\n\n${reflectionsMid.trim()}\n\n`;
-  }
-
-  if (reflectionsPost?.trim()) {
-    msg += `## Coach Post-Meeting Reflections\n\nWritten later in the day with more time to reflect.\n\n${reflectionsPost.trim()}\n\n`;
-  }
 
   msg += `Return JSON only.`;
   return msg;
@@ -472,11 +462,11 @@ export default async function handler(
     const teamReflection = sigReflection?.teams?.find(
       (t: any) => t.capNoteId?.toString() === id
     );
-    const reflectionsPre = teamReflection?.coachReflections?.pre ?? '';
-    const reflectionsMid = teamReflection?.coachReflections?.mid ?? '';
-    const reflectionsPost = teamReflection?.coachReflections?.post ?? '';
+    const reflections = typeof teamReflection?.coachReflections === 'string'
+      ? teamReflection.coachReflections
+      : '';
 
-    if (!reflectionsPre.trim() || !reflectionsMid.trim()) {
+    if (!reflections.trim()) {
       return res.status(400).json({
         success: false,
         error: 'REFLECTIONS_REQUIRED'
@@ -533,9 +523,7 @@ export default async function handler(
       capNote.project,
       capNote.sigName,
       transcript,
-      reflectionsPre,
-      reflectionsMid,
-      reflectionsPost,
+      reflections,
       priorNotesText,
       practiceGapsText,
       peerCasesText,

--- a/pages/api/sig-reflection/[sigAbbreviation].ts
+++ b/pages/api/sig-reflection/[sigAbbreviation].ts
@@ -24,32 +24,37 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'PATCH') {
     const { weekOf, project, capNoteId, coachReflections } = req.body;
-    if (!weekOf || !project || !capNoteId || !coachReflections) {
+    if (!weekOf || !project || !capNoteId || coachReflections === undefined) {
       return res
         .status(400)
         .json({ success: false, error: 'weekOf, project, capNoteId, and coachReflections required' });
     }
-    const week = getMondayOfWeek(new Date(weekOf));
+    try {
+      const week = getMondayOfWeek(new Date(weekOf));
 
-    let reflection = await SIGReflectionModel.findOne({ sigAbbreviation, weekOf: week });
-    if (!reflection) {
-      reflection = await SIGReflectionModel.create({
-        sigAbbreviation,
-        weekOf: week,
-        teams: [{ project, capNoteId, coachReflections, lastReflectionSavedAt: new Date().toISOString() }]
-      });
+      let reflection = await SIGReflectionModel.findOne({ sigAbbreviation, weekOf: week });
+      if (!reflection) {
+        reflection = await SIGReflectionModel.create({
+          sigAbbreviation,
+          weekOf: week,
+          teams: [{ project, capNoteId, coachReflections, lastReflectionSavedAt: new Date().toISOString() }]
+        });
+        return res.status(200).json({ success: true, data: reflection });
+      }
+
+      const teamIndex = reflection.teams.findIndex((t) => t.capNoteId?.toString() === capNoteId);
+      if (teamIndex === -1) {
+        reflection.teams.push({ project, capNoteId, coachReflections, lastReflectionSavedAt: new Date().toISOString() } as any);
+      } else {
+        reflection.teams[teamIndex].coachReflections = coachReflections;
+        reflection.teams[teamIndex].lastReflectionSavedAt = new Date().toISOString();
+      }
+      await reflection.save();
       return res.status(200).json({ success: true, data: reflection });
+    } catch (err) {
+      console.error('PATCH sig-reflection error:', err);
+      return res.status(500).json({ success: false, error: err instanceof Error ? err.message : String(err) });
     }
-
-    const teamIndex = reflection.teams.findIndex((t) => t.capNoteId?.toString() === capNoteId);
-    if (teamIndex === -1) {
-      reflection.teams.push({ project, capNoteId, coachReflections, lastReflectionSavedAt: new Date().toISOString() } as any);
-    } else {
-      reflection.teams[teamIndex].coachReflections = coachReflections;
-      reflection.teams[teamIndex].lastReflectionSavedAt = new Date().toISOString();
-    }
-    await reflection.save();
-    return res.status(200).json({ success: true, data: reflection });
   }
 
   return res.status(405).json({ success: false, error: 'Method not allowed' });

--- a/pages/coach-reflections/[sigAbbreviation].tsx
+++ b/pages/coach-reflections/[sigAbbreviation].tsx
@@ -10,16 +10,10 @@ import ExclamationCircleIcon from '@heroicons/react/24/outline/ExclamationCircle
 import { longDate, shortDateFromISO, getMondayOfWeek } from '../../lib/helperFns';
 import { useTeamRecording, TranscriptEntry } from '../../lib/useTeamRecording';
 
-interface CoachReflections {
-  pre: string;
-  mid: string;
-  post: string;
-}
-
 interface TeamData {
   project: string;
   capNoteId: string;
-  coachReflections: CoachReflections;
+  coachReflections: string;
   transcripts: TranscriptEntry[];
   members: string[];
 }
@@ -38,24 +32,6 @@ interface PageProps {
   weekOptions: WeekOption[];
 }
 
-const phases: { key: keyof CoachReflections; label: string; hint: string }[] = [
-  {
-    key: 'pre',
-    label: 'Pre-Meeting',
-    hint: 'After reviewing deliverables and student reflections, before the meeting.'
-  },
-  {
-    key: 'mid',
-    label: 'Mid-Meeting',
-    hint: "Immediately after this team's turn in the SIG meeting."
-  },
-  {
-    key: 'post',
-    label: 'Post-Meeting',
-    hint: 'Later in the day with more time to reflect.'
-  }
-];
-
 // ─── Per-team section ────────────────────────────────────────────────────────
 
 function TeamSection({
@@ -73,10 +49,10 @@ function TeamSection({
 }) {
   const recording = useTeamRecording(team.capNoteId, team.transcripts, team.members);
   const [showRecording, setShowRecording] = useState(false);
-  const [reflections, setReflections] = useState<CoachReflections>(team.coachReflections);
+  const [reflections, setReflections] = useState<string>(team.coachReflections);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const save = async (updated: CoachReflections) => {
+  const save = async (updated: string) => {
     onSaveStart();
     try {
       const res = await fetch(`/api/sig-reflection/${sigAbbreviation}`, {
@@ -92,17 +68,15 @@ function TeamSection({
       const json = await res.json();
       if (!json.success) throw new Error(json.error ?? 'Save failed');
       onSaveEnd(null);
-
     } catch (e: any) {
       onSaveEnd(e.message ?? 'Unknown error');
     }
   };
 
-  const handleChange = (field: keyof CoachReflections, value: string) => {
-    const updated = { ...reflections, [field]: value };
-    setReflections(updated);
+  const handleChange = (value: string) => {
+    setReflections(value);
     if (saveTimer.current) clearTimeout(saveTimer.current);
-    saveTimer.current = setTimeout(() => save(updated), 1200);
+    saveTimer.current = setTimeout(() => save(value), 1200);
   };
 
   const {
@@ -440,20 +414,18 @@ function TeamSection({
         </div>
 
         {/* ── Coach reflections ────────────────────────────────────────── */}
-        <div className="flex flex-col gap-5">
-          {phases.map(({ key, label, hint }) => (
-            <div key={key}>
-              <h3 className="mb-0.5 text-sm font-bold">{label}</h3>
-              <p className="mb-1 text-xs text-slate-500">{hint}</p>
-              <textarea
-                className="w-full rounded border p-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-300"
-                rows={4}
-                value={reflections[key]}
-                onChange={(e) => handleChange(key, e.target.value)}
-                placeholder={`${label} reflection…`}
-              />
-            </div>
-          ))}
+        <div>
+          <h3 className="mb-0.5 text-sm font-bold">Reflections</h3>
+          <p className="mb-1 text-xs text-slate-500">
+            Write your thoughts before the meeting starts, then add more right after this team&apos;s turn ends.
+          </p>
+          <textarea
+            className="w-full rounded border p-2 text-sm leading-relaxed focus:outline-none focus:ring-2 focus:ring-blue-300"
+            rows={6}
+            value={reflections}
+            onChange={(e) => handleChange(e.target.value)}
+            placeholder="Reflections…"
+          />
         </div>
       </div>
     </div>
@@ -717,11 +689,9 @@ export const getServerSideProps: GetServerSideProps = async ({ params, query }) 
       return {
         project: note.project,
         capNoteId: noteId,
-        coachReflections: {
-          pre: teamReflection?.coachReflections?.pre ?? '',
-          mid: teamReflection?.coachReflections?.mid ?? '',
-          post: teamReflection?.coachReflections?.post ?? ''
-        },
+        coachReflections: typeof teamReflection?.coachReflections === 'string'
+          ? teamReflection.coachReflections
+          : '',
         transcripts,
         members: sigMembers.map((m) => m.name)
       };


### PR DESCRIPTION
refactor(coach-reflections): single reflection box per team, try-catch on PATCH

- SIGReflectionModel: coachReflections is now a plain String (was { pre, mid, post })
- coach-reflections page: single textarea per team replacing three-phase boxes
- ai-draft API: reflections guard and prompt use single string
- sig-reflection PATCH: wrapped in try-catch so errors return JSON instead of HTML 500